### PR TITLE
linker: add support for odm partition

### DIFF
--- a/hybris/common/mm/linker.cpp
+++ b/hybris/common/mm/linker.cpp
@@ -85,9 +85,11 @@ static const char* const kDefaultLdPaths[] = {
 #if defined(__LP64__)
   "/vendor/lib64",
   "/system/lib64",
+  "/odm/lib64",
 #else
   "/vendor/lib",
   "/system/lib",
+  "/odm/lib",
 #endif
   nullptr
 };

--- a/hybris/common/n/linker.cpp
+++ b/hybris/common/n/linker.cpp
@@ -169,18 +169,23 @@ static soinfo* somain; // main process, always the one after libdl_info
 #if defined(__LP64__)
 static const char* const kSystemLibDir     = "/system/lib64";
 static const char* const kVendorLibDir     = "/vendor/lib64";
+static const char* const kOdmLibDir        = "/odm/lib64";
 static const char* const kAsanSystemLibDir = "/data/lib64";
 static const char* const kAsanVendorLibDir = "/data/vendor/lib64";
+static const char* const kAsanOdmLibDir    = "/data/odm/lib64";
 #else
 static const char* const kSystemLibDir     = "/system/lib";
 static const char* const kVendorLibDir     = "/vendor/lib";
+static const char* const kOdmLibDir        = "/odm/lib";
 static const char* const kAsanSystemLibDir = "/data/lib";
 static const char* const kAsanVendorLibDir = "/data/vendor/lib";
+static const char* const kAsanOdmLibDir    = "/data/odm/lib";
 #endif
 
 static const char* const kDefaultLdPaths[] = {
   kSystemLibDir,
   kVendorLibDir,
+  kOdmLibDir,
   nullptr
 };
 
@@ -189,6 +194,8 @@ static const char* const kAsanDefaultLdPaths[] = {
   kSystemLibDir,
   kAsanVendorLibDir,
   kVendorLibDir,
+  kAsanOdmLibDir,
+  kOdmLibDir,
   nullptr
 };
 
@@ -2503,6 +2510,12 @@ void* do_dlopen(const char* name, int flags, const android_dlextinfo* extinfo,
       }
     } else if (file_is_in_dir(name, kVendorLibDir)) {
       asan_name_holder = std::string(kAsanVendorLibDir) + "/" + basename(name);
+      if (file_exists(asan_name_holder.c_str())) {
+        translated_name = asan_name_holder.c_str();
+        PRINT("linker_asan dlopen translating \"%s\" -> \"%s\"", name, translated_name);
+      }
+    } else if (file_is_in_dir(name, kOdmLibDir)) {
+      asan_name_holder = std::string(kAsanOdmLibDir) + "/" + basename(name);
       if (file_exists(asan_name_holder.c_str())) {
         translated_name = asan_name_holder.c_str();
         PRINT("linker_asan dlopen translating \"%s\" -> \"%s\"", name, translated_name);

--- a/hybris/configure.ac
+++ b/hybris/configure.ac
@@ -137,9 +137,9 @@ AC_ARG_WITH(default-egl-platform,
 AC_SUBST(DEFAULT_EGL_PLATFORM)
 
 if test "x$arch" = "xarm" -o "x$arch" = "xx86"; then
-  DEFAULT_HYBRIS_LD_LIBRARY_PATH="/vendor/lib:/system/lib"
+  DEFAULT_HYBRIS_LD_LIBRARY_PATH="/vendor/lib:/system/lib:/odm/lib"
 else
-  DEFAULT_HYBRIS_LD_LIBRARY_PATH="/vendor/lib64:/system/lib64"
+  DEFAULT_HYBRIS_LD_LIBRARY_PATH="/vendor/lib64:/system/lib64:/odm/lib64"
 fi
 AC_ARG_WITH(default-hybris-ld-library-path,
   [  --with-default-hybris-ld-library-path=PATH1:PATH2:...     Use PATH1:PATH2 for default HYBRIS_LD_LIBRARY_PATH if not specified by environment ],


### PR DESCRIPTION
Android O Treble project moves proprietary vendor binaries to a separate /odm
partition.

Manufacturers like Sony start moving to the new layout as early as possible [1][2],
hence we need to adapt libhybris as well.

[1] https://android.googlesource.com/platform/bionic/+/0e093b770af71a9da6e6556ce6f2bda8ba4fb40b%5E%21/#F0
[2] https://android.googlesource.com/platform/bionic/+/645587e5590f5ca42dc3ceecd0085cc446e92ccb%5E!/#F0