### PR TITLE
Include compatibility library for HWComposer 2 support

### DIFF
--- a/compat/hwc2/Android.mk
+++ b/compat/hwc2/Android.mk
@@ -1,0 +1,112 @@
+# define ANDROID_VERSION MAJOR, MINOR and PATCH
+
+ANDROID_VERSION_MAJOR := $(word 1, $(subst ., , $(PLATFORM_VERSION)))
+ANDROID_VERSION_MINOR := $(word 2, $(subst ., , $(PLATFORM_VERSION)))
+ANDROID_VERSION_PATCH := $(word 3, $(subst ., , $(PLATFORM_VERSION)))
+
+LOCAL_PATH:= $(call my-dir)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := libhwc2_compat_layer
+LOCAL_SRC_FILES := HWC2.cpp ComposerHal.cpp hwc2_compatibility_layer.cpp
+
+LOCAL_STATIC_LIBRARIES := \
+    libhwcomposer-command-buffer \
+    libhwcnativewindow libhybris-gralloc
+
+LOCAL_SHARED_LIBRARIES := \
+    android.frameworks.vr.composer@1.0 \
+    android.hardware.graphics.allocator@2.0 \
+    android.hardware.graphics.composer@2.1 \
+    android.hardware.configstore@1.0 \
+    android.hardware.configstore-utils \
+    libcutils \
+    liblog \
+    libfmq \
+    libhardware \
+    libhidlbase \
+    libhidltransport \
+    libhwbinder \
+    libutils \
+    libEGL \
+    libGLESv1_CM \
+    libGLESv2 \
+    libbinder \
+    libui \
+    libgui \
+    libsync \
+    libbase \
+    libnativewindow
+
+LOCAL_EXPORT_SHARED_LIBRARY_HEADERS := \
+    android.hardware.graphics.allocator@2.0 \
+    android.hardware.graphics.composer@2.1 \
+    libhidlbase \
+    libhidltransport \
+    libhwbinder
+
+LOCAL_CFLAGS += -Wno-unused-parameter -DGL_GLEXT_PROTOTYPES -UNDEBUG
+LOCAL_CFLAGS += \
+    -DANDROID_VERSION_MAJOR=$(ANDROID_VERSION_MAJOR) \
+    -DANDROID_VERSION_MINOR=$(ANDROID_VERSION_MINOR) \
+    -DANDROID_VERSION_PATCH=$(ANDROID_VERSION_PATCH)
+
+include $(BUILD_SHARED_LIBRARY)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := libhybris-gralloc
+LOCAL_SRC_FILES := tests/hybris-gralloc.c \
+    tests/GrallocUsageConversion.cpp
+LOCAL_C_INCLUDES := $(LOCAL_PATH)/tests
+
+LOCAL_SHARED_LIBRARIES := libcutils
+LOCAL_CFLAGS := \
+    -DANDROID_VERSION_MAJOR=$(ANDROID_VERSION_MAJOR) \
+    -DANDROID_VERSION_MINOR=$(ANDROID_VERSION_MINOR) \
+    -DANDROID_VERSION_PATCH=$(ANDROID_VERSION_PATCH)
+LOCAL_CFLAGS += -Wno-unused-parameter -UNDEBUG -DHAS_GRALLOC1_HEADER=1
+include $(BUILD_STATIC_LIBRARY)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := libhwcnativewindow
+LOCAL_SRC_FILES := tests/hwcomposer_window.cpp \
+    tests/nativewindowbase.cpp
+LOCAL_SHARED_LIBRARIES := libsync liblog libnativewindow
+LOCAL_CFLAGS := \
+    -DANDROID_VERSION_MAJOR=$(ANDROID_VERSION_MAJOR) \
+    -DANDROID_VERSION_MINOR=$(ANDROID_VERSION_MINOR) \
+    -DANDROID_VERSION_PATCH=$(ANDROID_VERSION_PATCH)
+LOCAL_CFLAGS += -Wno-unused-parameter -UNDEBUG
+include $(BUILD_STATIC_LIBRARY)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := direct_hwc2_test
+LOCAL_SRC_FILES := tests/direct_hwc2_test.cpp
+LOCAL_C_INCLUDES := $(LOCAL_PATH)/tests
+ifdef TARGET_2ND_ARCH
+LOCAL_MULTILIB := both
+LOCAL_MODULE_STEM_32 := $(if $(filter false,$(BOARD_UBUNTU_PREFER_32_BIT)),$(LOCAL_MODULE)$(TARGET_2ND_ARCH_MODULE_SUFFIX),$(LOCAL_MODULE))
+LOCAL_MODULE_STEM_64 := $(if $(filter false,$(BOARD_UBUNTU_PREFER_32_BIT)),$(LOCAL_MODULE),$(LOCAL_MODULE)_64)
+endif
+
+LOCAL_STATIC_LIBRARIES := \
+    libhwcnativewindow libhybris-gralloc
+
+LOCAL_SHARED_LIBRARIES := \
+    libcutils \
+    liblog \
+    libhardware \
+    libnativewindow \
+    libsync \
+    libEGL \
+    libGLESv2 \
+    libhwc2_compat_layer
+
+LOCAL_CFLAGS += -Wno-unused-parameter -DGL_GLEXT_PROTOTYPES -UNDEBUG \
+    -DHWC2_USE_CPP11 -DHWC2_INCLUDE_STRINGIFICATION
+LOCAL_CFLAGS += \
+	-DANDROID_VERSION_MAJOR=$(ANDROID_VERSION_MAJOR) \
+	-DANDROID_VERSION_MINOR=$(ANDROID_VERSION_MINOR) \
+	-DANDROID_VERSION_PATCH=$(ANDROID_VERSION_PATCH)
+
+include $(BUILD_EXECUTABLE)

--- a/compat/hwc2/ComposerHal.cpp
+++ b/compat/hwc2/ComposerHal.cpp
@@ -1,0 +1,1118 @@
+/*
+ * Copyright 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#undef LOG_TAG
+#define LOG_TAG "HwcComposer"
+
+#include <inttypes.h>
+#include <log/log.h>
+#include <gui/BufferQueue.h>
+
+#include "ComposerHal.h"
+
+namespace android {
+
+using hardware::Return;
+using hardware::hidl_vec;
+using hardware::hidl_handle;
+
+namespace Hwc2 {
+
+namespace {
+
+class BufferHandle {
+public:
+    BufferHandle(const native_handle_t* buffer)
+    {
+        // nullptr is not a valid handle to HIDL
+        mHandle = (buffer) ? buffer : native_handle_init(mStorage, 0, 0);
+    }
+
+    operator const hidl_handle&() const
+    {
+        return mHandle;
+    }
+
+private:
+    NATIVE_HANDLE_DECLARE_STORAGE(mStorage, 0, 0);
+    hidl_handle mHandle;
+};
+
+class FenceHandle
+{
+public:
+    FenceHandle(int fd, bool owned)
+        : mOwned(owned)
+    {
+        native_handle_t* handle;
+        if (fd >= 0) {
+            handle = native_handle_init(mStorage, 1, 0);
+            handle->data[0] = fd;
+        } else {
+            // nullptr is not a valid handle to HIDL
+            handle = native_handle_init(mStorage, 0, 0);
+        }
+        mHandle = handle;
+    }
+
+    ~FenceHandle()
+    {
+        if (mOwned) {
+            native_handle_close(mHandle);
+        }
+    }
+
+    operator const hidl_handle&() const
+    {
+        return mHandle;
+    }
+
+private:
+    bool mOwned;
+    NATIVE_HANDLE_DECLARE_STORAGE(mStorage, 1, 0);
+    hidl_handle mHandle;
+};
+
+// assume NO_RESOURCES when Status::isOk returns false
+constexpr Error kDefaultError = Error::NO_RESOURCES;
+
+template<typename T, typename U>
+T unwrapRet(Return<T>& ret, const U& default_val)
+{
+    return (ret.isOk()) ? static_cast<T>(ret) :
+        static_cast<T>(default_val);
+}
+
+Error unwrapRet(Return<Error>& ret)
+{
+    return unwrapRet(ret, kDefaultError);
+}
+
+} // anonymous namespace
+
+Composer::CommandWriter::CommandWriter(uint32_t initialMaxSize)
+    : CommandWriterBase(initialMaxSize) {}
+
+Composer::CommandWriter::~CommandWriter()
+{
+}
+
+void Composer::CommandWriter::setLayerInfo(uint32_t type, uint32_t appId)
+{
+    constexpr uint16_t kSetLayerInfoLength = 2;
+    beginCommand(
+        static_cast<IComposerClient::Command>(
+            IVrComposerClient::VrCommand::SET_LAYER_INFO),
+        kSetLayerInfoLength);
+    write(type);
+    write(appId);
+    endCommand();
+}
+
+void Composer::CommandWriter::setClientTargetMetadata(
+        const IVrComposerClient::BufferMetadata& metadata)
+{
+    constexpr uint16_t kSetClientTargetMetadataLength = 7;
+    beginCommand(
+        static_cast<IComposerClient::Command>(
+            IVrComposerClient::VrCommand::SET_CLIENT_TARGET_METADATA),
+        kSetClientTargetMetadataLength);
+    writeBufferMetadata(metadata);
+    endCommand();
+}
+
+void Composer::CommandWriter::setLayerBufferMetadata(
+        const IVrComposerClient::BufferMetadata& metadata)
+{
+    constexpr uint16_t kSetLayerBufferMetadataLength = 7;
+    beginCommand(
+        static_cast<IComposerClient::Command>(
+            IVrComposerClient::VrCommand::SET_LAYER_BUFFER_METADATA),
+        kSetLayerBufferMetadataLength);
+    writeBufferMetadata(metadata);
+    endCommand();
+}
+
+void Composer::CommandWriter::writeBufferMetadata(
+        const IVrComposerClient::BufferMetadata& metadata)
+{
+    write(metadata.width);
+    write(metadata.height);
+    write(metadata.stride);
+    write(metadata.layerCount);
+    writeSigned(static_cast<int32_t>(metadata.format));
+    write64(metadata.usage);
+}
+
+Composer::Composer(bool useVrComposer)
+    : mWriter(kWriterInitialSize),
+      mIsUsingVrComposer(useVrComposer)
+{
+    if (mIsUsingVrComposer) {
+        mComposer = IComposer::getService("vr");
+    } else {
+        mComposer = IComposer::getService(); // use default name
+    }
+
+    if (mComposer == nullptr) {
+        LOG_ALWAYS_FATAL("failed to get hwcomposer service");
+    }
+
+    mComposer->createClient(
+            [&](const auto& tmpError, const auto& tmpClient)
+            {
+                if (tmpError == Error::NONE) {
+                    mClient = tmpClient;
+                }
+            });
+    if (mClient == nullptr) {
+        LOG_ALWAYS_FATAL("failed to create composer client");
+    }
+
+    if (mIsUsingVrComposer) {
+        sp<IVrComposerClient> vrClient = IVrComposerClient::castFrom(mClient);
+        if (vrClient == nullptr) {
+            LOG_ALWAYS_FATAL("failed to create vr composer client");
+        }
+    }
+}
+
+std::vector<IComposer::Capability> Composer::getCapabilities()
+{
+    std::vector<IComposer::Capability> capabilities;
+    mComposer->getCapabilities(
+            [&](const auto& tmpCapabilities) {
+                capabilities = tmpCapabilities;
+            });
+
+    return capabilities;
+}
+
+std::string Composer::dumpDebugInfo()
+{
+    std::string info;
+    mComposer->dumpDebugInfo([&](const auto& tmpInfo) {
+        info = tmpInfo.c_str();
+    });
+
+    return info;
+}
+
+void Composer::registerCallback(const sp<IComposerCallback>& callback)
+{
+    auto ret = mClient->registerCallback(callback);
+    if (!ret.isOk()) {
+        ALOGE("failed to register IComposerCallback");
+    }
+}
+
+bool Composer::isRemote() {
+    return mClient->isRemote();
+}
+
+void Composer::resetCommands() {
+    mWriter.reset();
+}
+
+uint32_t Composer::getMaxVirtualDisplayCount()
+{
+    auto ret = mClient->getMaxVirtualDisplayCount();
+    return unwrapRet(ret, 0);
+}
+
+Error Composer::createVirtualDisplay(uint32_t width, uint32_t height,
+            PixelFormat* format, Display* outDisplay)
+{
+    const uint32_t bufferSlotCount = 1;
+    Error error = kDefaultError;
+    mClient->createVirtualDisplay(width, height, *format, bufferSlotCount,
+            [&](const auto& tmpError, const auto& tmpDisplay,
+                const auto& tmpFormat) {
+                error = tmpError;
+                if (error != Error::NONE) {
+                    return;
+                }
+
+                *outDisplay = tmpDisplay;
+                *format = tmpFormat;
+            });
+
+    return error;
+}
+
+Error Composer::destroyVirtualDisplay(Display display)
+{
+    auto ret = mClient->destroyVirtualDisplay(display);
+    return unwrapRet(ret);
+}
+
+Error Composer::acceptDisplayChanges(Display display)
+{
+    mWriter.selectDisplay(display);
+    mWriter.acceptDisplayChanges();
+    return Error::NONE;
+}
+
+Error Composer::createLayer(Display display, Layer* outLayer)
+{
+    Error error = kDefaultError;
+    mClient->createLayer(display, BufferQueue::NUM_BUFFER_SLOTS,
+            [&](const auto& tmpError, const auto& tmpLayer) {
+                error = tmpError;
+                if (error != Error::NONE) {
+                    return;
+                }
+
+                *outLayer = tmpLayer;
+            });
+
+    return error;
+}
+
+Error Composer::destroyLayer(Display display, Layer layer)
+{
+    auto ret = mClient->destroyLayer(display, layer);
+    return unwrapRet(ret);
+}
+
+Error Composer::getActiveConfig(Display display, Config* outConfig)
+{
+    Error error = kDefaultError;
+    mClient->getActiveConfig(display,
+            [&](const auto& tmpError, const auto& tmpConfig) {
+                error = tmpError;
+                if (error != Error::NONE) {
+                    return;
+                }
+
+                *outConfig = tmpConfig;
+            });
+
+    return error;
+}
+
+Error Composer::getChangedCompositionTypes(Display display,
+        std::vector<Layer>* outLayers,
+        std::vector<IComposerClient::Composition>* outTypes)
+{
+    mReader.takeChangedCompositionTypes(display, outLayers, outTypes);
+    return Error::NONE;
+}
+
+Error Composer::getColorModes(Display display,
+        std::vector<ColorMode>* outModes)
+{
+    Error error = kDefaultError;
+    mClient->getColorModes(display,
+            [&](const auto& tmpError, const auto& tmpModes) {
+                error = tmpError;
+                if (error != Error::NONE) {
+                    return;
+                }
+
+                *outModes = tmpModes;
+            });
+
+    return error;
+}
+
+Error Composer::getDisplayAttribute(Display display, Config config,
+        IComposerClient::Attribute attribute, int32_t* outValue)
+{
+    Error error = kDefaultError;
+    mClient->getDisplayAttribute(display, config, attribute,
+            [&](const auto& tmpError, const auto& tmpValue) {
+                error = tmpError;
+                if (error != Error::NONE) {
+                    return;
+                }
+
+                *outValue = tmpValue;
+            });
+
+    return error;
+}
+
+Error Composer::getDisplayConfigs(Display display,
+        std::vector<Config>* outConfigs)
+{
+    Error error = kDefaultError;
+    mClient->getDisplayConfigs(display,
+            [&](const auto& tmpError, const auto& tmpConfigs) {
+                error = tmpError;
+                if (error != Error::NONE) {
+                    return;
+                }
+
+                *outConfigs = tmpConfigs;
+            });
+
+    return error;
+}
+
+Error Composer::getDisplayName(Display display, std::string* outName)
+{
+    Error error = kDefaultError;
+    mClient->getDisplayName(display,
+            [&](const auto& tmpError, const auto& tmpName) {
+                error = tmpError;
+                if (error != Error::NONE) {
+                    return;
+                }
+
+                *outName = tmpName.c_str();
+            });
+
+    return error;
+}
+
+Error Composer::getDisplayRequests(Display display,
+        uint32_t* outDisplayRequestMask, std::vector<Layer>* outLayers,
+        std::vector<uint32_t>* outLayerRequestMasks)
+{
+    mReader.takeDisplayRequests(display, outDisplayRequestMask,
+            outLayers, outLayerRequestMasks);
+    return Error::NONE;
+}
+
+Error Composer::getDisplayType(Display display,
+        IComposerClient::DisplayType* outType)
+{
+    Error error = kDefaultError;
+    mClient->getDisplayType(display,
+            [&](const auto& tmpError, const auto& tmpType) {
+                error = tmpError;
+                if (error != Error::NONE) {
+                    return;
+                }
+
+                *outType = tmpType;
+            });
+
+    return error;
+}
+
+Error Composer::getDozeSupport(Display display, bool* outSupport)
+{
+    Error error = kDefaultError;
+    mClient->getDozeSupport(display,
+            [&](const auto& tmpError, const auto& tmpSupport) {
+                error = tmpError;
+                if (error != Error::NONE) {
+                    return;
+                }
+
+                *outSupport = tmpSupport;
+            });
+
+    return error;
+}
+
+Error Composer::getHdrCapabilities(Display display,
+        std::vector<Hdr>* outTypes, float* outMaxLuminance,
+        float* outMaxAverageLuminance, float* outMinLuminance)
+{
+    Error error = kDefaultError;
+    mClient->getHdrCapabilities(display,
+            [&](const auto& tmpError, const auto& tmpTypes,
+                const auto& tmpMaxLuminance,
+                const auto& tmpMaxAverageLuminance,
+                const auto& tmpMinLuminance) {
+                error = tmpError;
+                if (error != Error::NONE) {
+                    return;
+                }
+
+                *outTypes = tmpTypes;
+                *outMaxLuminance = tmpMaxLuminance;
+                *outMaxAverageLuminance = tmpMaxAverageLuminance;
+                *outMinLuminance = tmpMinLuminance;
+            });
+
+    return error;
+}
+
+Error Composer::getReleaseFences(Display display,
+        std::vector<Layer>* outLayers, std::vector<int>* outReleaseFences)
+{
+    mReader.takeReleaseFences(display, outLayers, outReleaseFences);
+    return Error::NONE;
+}
+
+Error Composer::presentDisplay(Display display, int* outPresentFence)
+{
+    mWriter.selectDisplay(display);
+    mWriter.presentDisplay();
+
+    Error error = execute();
+    if (error != Error::NONE) {
+        return error;
+    }
+
+    mReader.takePresentFence(display, outPresentFence);
+
+    return Error::NONE;
+}
+
+Error Composer::setActiveConfig(Display display, Config config)
+{
+    auto ret = mClient->setActiveConfig(display, config);
+    return unwrapRet(ret);
+}
+
+Error Composer::setClientTarget(Display display, uint32_t slot,
+        const sp<GraphicBuffer>& target,
+        int acquireFence, Dataspace dataspace,
+        const std::vector<IComposerClient::Rect>& damage)
+{
+    mWriter.selectDisplay(display);
+    if (mIsUsingVrComposer && target.get()) {
+        IVrComposerClient::BufferMetadata metadata = {
+            .width = target->getWidth(),
+            .height = target->getHeight(),
+            .stride = target->getStride(),
+            .layerCount = target->getLayerCount(),
+            .format = static_cast<PixelFormat>(target->getPixelFormat()),
+            .usage = target->getUsage(),
+        };
+        mWriter.setClientTargetMetadata(metadata);
+    }
+
+    const native_handle_t* handle = nullptr;
+    if (target.get()) {
+        handle = target->getNativeBuffer()->handle;
+    }
+
+    mWriter.setClientTarget(slot, handle, acquireFence, dataspace, damage);
+    return Error::NONE;
+}
+
+Error Composer::setColorMode(Display display, ColorMode mode)
+{
+    auto ret = mClient->setColorMode(display, mode);
+    return unwrapRet(ret);
+}
+
+Error Composer::setColorTransform(Display display, const float* matrix,
+        ColorTransform hint)
+{
+    mWriter.selectDisplay(display);
+    mWriter.setColorTransform(matrix, hint);
+    return Error::NONE;
+}
+
+Error Composer::setOutputBuffer(Display display, const native_handle_t* buffer,
+        int releaseFence)
+{
+    mWriter.selectDisplay(display);
+    mWriter.setOutputBuffer(0, buffer, dup(releaseFence));
+    return Error::NONE;
+}
+
+Error Composer::setPowerMode(Display display, IComposerClient::PowerMode mode)
+{
+    auto ret = mClient->setPowerMode(display, mode);
+    return unwrapRet(ret);
+}
+
+Error Composer::setVsyncEnabled(Display display, IComposerClient::Vsync enabled)
+{
+    auto ret = mClient->setVsyncEnabled(display, enabled);
+    return unwrapRet(ret);
+}
+
+Error Composer::setClientTargetSlotCount(Display display)
+{
+    const uint32_t bufferSlotCount = BufferQueue::NUM_BUFFER_SLOTS;
+    auto ret = mClient->setClientTargetSlotCount(display, bufferSlotCount);
+    return unwrapRet(ret);
+}
+
+Error Composer::validateDisplay(Display display, uint32_t* outNumTypes,
+        uint32_t* outNumRequests)
+{
+    mWriter.selectDisplay(display);
+    mWriter.validateDisplay();
+
+    Error error = execute();
+    if (error != Error::NONE) {
+        return error;
+    }
+
+    mReader.hasChanges(display, outNumTypes, outNumRequests);
+
+    return Error::NONE;
+}
+
+Error Composer::presentOrValidateDisplay(Display display, uint32_t* outNumTypes,
+                               uint32_t* outNumRequests, int* outPresentFence, uint32_t* state) {
+   mWriter.selectDisplay(display);
+   mWriter.presentOrvalidateDisplay();
+
+   Error error = execute();
+   if (error != Error::NONE) {
+       return error;
+   }
+
+   mReader.takePresentOrValidateStage(display, state);
+
+   if (*state == 1) { // Present succeeded
+       mReader.takePresentFence(display, outPresentFence);
+   }
+
+   if (*state == 0) { // Validate succeeded.
+       mReader.hasChanges(display, outNumTypes, outNumRequests);
+   }
+
+   return Error::NONE;
+}
+
+Error Composer::setCursorPosition(Display display, Layer layer,
+        int32_t x, int32_t y)
+{
+    mWriter.selectDisplay(display);
+    mWriter.selectLayer(layer);
+    mWriter.setLayerCursorPosition(x, y);
+    return Error::NONE;
+}
+
+Error Composer::setLayerBuffer(Display display, Layer layer,
+        uint32_t slot, const sp<GraphicBuffer>& buffer, int acquireFence)
+{
+    mWriter.selectDisplay(display);
+    mWriter.selectLayer(layer);
+    if (mIsUsingVrComposer && buffer.get()) {
+        IVrComposerClient::BufferMetadata metadata = {
+            .width = buffer->getWidth(),
+            .height = buffer->getHeight(),
+            .stride = buffer->getStride(),
+            .layerCount = buffer->getLayerCount(),
+            .format = static_cast<PixelFormat>(buffer->getPixelFormat()),
+            .usage = buffer->getUsage(),
+        };
+        mWriter.setLayerBufferMetadata(metadata);
+    }
+
+    const native_handle_t* handle = nullptr;
+    if (buffer.get()) {
+        handle = buffer->getNativeBuffer()->handle;
+    }
+
+    mWriter.setLayerBuffer(slot, handle, acquireFence);
+    return Error::NONE;
+}
+
+Error Composer::setLayerSurfaceDamage(Display display, Layer layer,
+        const std::vector<IComposerClient::Rect>& damage)
+{
+    mWriter.selectDisplay(display);
+    mWriter.selectLayer(layer);
+    mWriter.setLayerSurfaceDamage(damage);
+    return Error::NONE;
+}
+
+Error Composer::setLayerBlendMode(Display display, Layer layer,
+        IComposerClient::BlendMode mode)
+{
+    mWriter.selectDisplay(display);
+    mWriter.selectLayer(layer);
+    mWriter.setLayerBlendMode(mode);
+    return Error::NONE;
+}
+
+Error Composer::setLayerColor(Display display, Layer layer,
+        const IComposerClient::Color& color)
+{
+    mWriter.selectDisplay(display);
+    mWriter.selectLayer(layer);
+    mWriter.setLayerColor(color);
+    return Error::NONE;
+}
+
+Error Composer::setLayerCompositionType(Display display, Layer layer,
+        IComposerClient::Composition type)
+{
+    mWriter.selectDisplay(display);
+    mWriter.selectLayer(layer);
+    mWriter.setLayerCompositionType(type);
+    return Error::NONE;
+}
+
+Error Composer::setLayerDataspace(Display display, Layer layer,
+        Dataspace dataspace)
+{
+    mWriter.selectDisplay(display);
+    mWriter.selectLayer(layer);
+    mWriter.setLayerDataspace(dataspace);
+    return Error::NONE;
+}
+
+Error Composer::setLayerDisplayFrame(Display display, Layer layer,
+        const IComposerClient::Rect& frame)
+{
+    mWriter.selectDisplay(display);
+    mWriter.selectLayer(layer);
+    mWriter.setLayerDisplayFrame(frame);
+    return Error::NONE;
+}
+
+Error Composer::setLayerPlaneAlpha(Display display, Layer layer,
+        float alpha)
+{
+    mWriter.selectDisplay(display);
+    mWriter.selectLayer(layer);
+    mWriter.setLayerPlaneAlpha(alpha);
+    return Error::NONE;
+}
+
+Error Composer::setLayerSidebandStream(Display display, Layer layer,
+        const native_handle_t* stream)
+{
+    mWriter.selectDisplay(display);
+    mWriter.selectLayer(layer);
+    mWriter.setLayerSidebandStream(stream);
+    return Error::NONE;
+}
+
+Error Composer::setLayerSourceCrop(Display display, Layer layer,
+        const IComposerClient::FRect& crop)
+{
+    mWriter.selectDisplay(display);
+    mWriter.selectLayer(layer);
+    mWriter.setLayerSourceCrop(crop);
+    return Error::NONE;
+}
+
+Error Composer::setLayerTransform(Display display, Layer layer,
+        Transform transform)
+{
+    mWriter.selectDisplay(display);
+    mWriter.selectLayer(layer);
+    mWriter.setLayerTransform(transform);
+    return Error::NONE;
+}
+
+Error Composer::setLayerVisibleRegion(Display display, Layer layer,
+        const std::vector<IComposerClient::Rect>& visible)
+{
+    mWriter.selectDisplay(display);
+    mWriter.selectLayer(layer);
+    mWriter.setLayerVisibleRegion(visible);
+    return Error::NONE;
+}
+
+Error Composer::setLayerZOrder(Display display, Layer layer, uint32_t z)
+{
+    mWriter.selectDisplay(display);
+    mWriter.selectLayer(layer);
+    mWriter.setLayerZOrder(z);
+    return Error::NONE;
+}
+
+Error Composer::setLayerInfo(Display display, Layer layer, uint32_t type,
+                             uint32_t appId)
+{
+    if (mIsUsingVrComposer) {
+        mWriter.selectDisplay(display);
+        mWriter.selectLayer(layer);
+        mWriter.setLayerInfo(type, appId);
+    }
+    return Error::NONE;
+}
+
+Error Composer::execute()
+{
+    // prepare input command queue
+    bool queueChanged = false;
+    uint32_t commandLength = 0;
+    hidl_vec<hidl_handle> commandHandles;
+    if (!mWriter.writeQueue(&queueChanged, &commandLength, &commandHandles)) {
+        mWriter.reset();
+        return Error::NO_RESOURCES;
+    }
+
+    // set up new input command queue if necessary
+    if (queueChanged) {
+        auto ret = mClient->setInputCommandQueue(*mWriter.getMQDescriptor());
+        auto error = unwrapRet(ret);
+        if (error != Error::NONE) {
+            mWriter.reset();
+            return error;
+        }
+    }
+
+    Error error = kDefaultError;
+    auto ret = mClient->executeCommands(commandLength, commandHandles,
+            [&](const auto& tmpError, const auto& tmpOutChanged,
+                const auto& tmpOutLength, const auto& tmpOutHandles)
+            {
+                error = tmpError;
+
+                // set up new output command queue if necessary
+                if (error == Error::NONE && tmpOutChanged) {
+                    error = kDefaultError;
+                    mClient->getOutputCommandQueue(
+                            [&](const auto& tmpError,
+                                const auto& tmpDescriptor)
+                            {
+                                error = tmpError;
+                                if (error != Error::NONE) {
+                                    return;
+                                }
+
+                                mReader.setMQDescriptor(tmpDescriptor);
+                            });
+                }
+
+                if (error != Error::NONE) {
+                    return;
+                }
+
+                if (mReader.readQueue(tmpOutLength, tmpOutHandles)) {
+                    error = mReader.parse();
+                    mReader.reset();
+                } else {
+                    error = Error::NO_RESOURCES;
+                }
+            });
+    // executeCommands can fail because of out-of-fd and we do not want to
+    // abort() in that case
+    if (!ret.isOk()) {
+        ALOGE("executeCommands failed because of %s", ret.description().c_str());
+    }
+
+    if (error == Error::NONE) {
+        std::vector<CommandReader::CommandError> commandErrors =
+            mReader.takeErrors();
+
+        for (const auto& cmdErr : commandErrors) {
+            auto command = mWriter.getCommand(cmdErr.location);
+
+            if (command == IComposerClient::Command::VALIDATE_DISPLAY ||
+                command == IComposerClient::Command::PRESENT_DISPLAY ||
+                command == IComposerClient::Command::PRESENT_OR_VALIDATE_DISPLAY) {
+                error = cmdErr.error;
+            } else {
+                ALOGW("command 0x%x generated error %d",
+                        command, cmdErr.error);
+            }
+        }
+    }
+
+    mWriter.reset();
+
+    return error;
+}
+
+CommandReader::~CommandReader()
+{
+    resetData();
+}
+
+Error CommandReader::parse()
+{
+    resetData();
+
+    IComposerClient::Command command;
+    uint16_t length = 0;
+
+    while (!isEmpty()) {
+        if (!beginCommand(&command, &length)) {
+            break;
+        }
+
+        bool parsed = false;
+        switch (command) {
+        case IComposerClient::Command::SELECT_DISPLAY:
+            parsed = parseSelectDisplay(length);
+            break;
+        case IComposerClient::Command::SET_ERROR:
+            parsed = parseSetError(length);
+            break;
+        case IComposerClient::Command::SET_CHANGED_COMPOSITION_TYPES:
+            parsed = parseSetChangedCompositionTypes(length);
+            break;
+        case IComposerClient::Command::SET_DISPLAY_REQUESTS:
+            parsed = parseSetDisplayRequests(length);
+            break;
+        case IComposerClient::Command::SET_PRESENT_FENCE:
+            parsed = parseSetPresentFence(length);
+            break;
+        case IComposerClient::Command::SET_RELEASE_FENCES:
+            parsed = parseSetReleaseFences(length);
+            break;
+        case IComposerClient::Command ::SET_PRESENT_OR_VALIDATE_DISPLAY_RESULT:
+            parsed = parseSetPresentOrValidateDisplayResult(length);
+            break;
+        default:
+            parsed = false;
+            break;
+        }
+
+        endCommand();
+
+        if (!parsed) {
+            ALOGE("failed to parse command 0x%x length %" PRIu16,
+                    command, length);
+            break;
+        }
+    }
+
+    return isEmpty() ? Error::NONE : Error::NO_RESOURCES;
+}
+
+bool CommandReader::parseSelectDisplay(uint16_t length)
+{
+    if (length != CommandWriterBase::kSelectDisplayLength) {
+        return false;
+    }
+
+    mCurrentReturnData = &mReturnData[read64()];
+
+    return true;
+}
+
+bool CommandReader::parseSetError(uint16_t length)
+{
+    if (length != CommandWriterBase::kSetErrorLength) {
+        return false;
+    }
+
+    auto location = read();
+    auto error = static_cast<Error>(readSigned());
+
+    mErrors.emplace_back(CommandError{location, error});
+
+    return true;
+}
+
+bool CommandReader::parseSetChangedCompositionTypes(uint16_t length)
+{
+    // (layer id, composition type) pairs
+    if (length % 3 != 0 || !mCurrentReturnData) {
+        return false;
+    }
+
+    uint32_t count = length / 3;
+    mCurrentReturnData->changedLayers.reserve(count);
+    mCurrentReturnData->compositionTypes.reserve(count);
+    while (count > 0) {
+        auto layer = read64();
+        auto type = static_cast<IComposerClient::Composition>(readSigned());
+
+        mCurrentReturnData->changedLayers.push_back(layer);
+        mCurrentReturnData->compositionTypes.push_back(type);
+
+        count--;
+    }
+
+    return true;
+}
+
+bool CommandReader::parseSetDisplayRequests(uint16_t length)
+{
+    // display requests followed by (layer id, layer requests) pairs
+    if (length % 3 != 1 || !mCurrentReturnData) {
+        return false;
+    }
+
+    mCurrentReturnData->displayRequests = read();
+
+    uint32_t count = (length - 1) / 3;
+    mCurrentReturnData->requestedLayers.reserve(count);
+    mCurrentReturnData->requestMasks.reserve(count);
+    while (count > 0) {
+        auto layer = read64();
+        auto layerRequestMask = read();
+
+        mCurrentReturnData->requestedLayers.push_back(layer);
+        mCurrentReturnData->requestMasks.push_back(layerRequestMask);
+
+        count--;
+    }
+
+    return true;
+}
+
+bool CommandReader::parseSetPresentFence(uint16_t length)
+{
+    if (length != CommandWriterBase::kSetPresentFenceLength ||
+            !mCurrentReturnData) {
+        return false;
+    }
+
+    if (mCurrentReturnData->presentFence >= 0) {
+        close(mCurrentReturnData->presentFence);
+    }
+    mCurrentReturnData->presentFence = readFence();
+
+    return true;
+}
+
+bool CommandReader::parseSetReleaseFences(uint16_t length)
+{
+    // (layer id, release fence index) pairs
+    if (length % 3 != 0 || !mCurrentReturnData) {
+        return false;
+    }
+
+    uint32_t count = length / 3;
+    mCurrentReturnData->releasedLayers.reserve(count);
+    mCurrentReturnData->releaseFences.reserve(count);
+    while (count > 0) {
+        auto layer = read64();
+        auto fence = readFence();
+
+        mCurrentReturnData->releasedLayers.push_back(layer);
+        mCurrentReturnData->releaseFences.push_back(fence);
+
+        count--;
+    }
+
+    return true;
+}
+
+bool CommandReader::parseSetPresentOrValidateDisplayResult(uint16_t length)
+{
+    if (length != CommandWriterBase::kPresentOrValidateDisplayResultLength || !mCurrentReturnData) {
+        return false;
+    }
+    mCurrentReturnData->presentOrValidateState = read();
+    return true;
+}
+
+void CommandReader::resetData()
+{
+    mErrors.clear();
+
+    for (auto& data : mReturnData) {
+        if (data.second.presentFence >= 0) {
+            close(data.second.presentFence);
+        }
+        for (auto fence : data.second.releaseFences) {
+            if (fence >= 0) {
+                close(fence);
+            }
+        }
+    }
+
+    mReturnData.clear();
+    mCurrentReturnData = nullptr;
+}
+
+std::vector<CommandReader::CommandError> CommandReader::takeErrors()
+{
+    return std::move(mErrors);
+}
+
+bool CommandReader::hasChanges(Display display,
+        uint32_t* outNumChangedCompositionTypes,
+        uint32_t* outNumLayerRequestMasks) const
+{
+    auto found = mReturnData.find(display);
+    if (found == mReturnData.end()) {
+        *outNumChangedCompositionTypes = 0;
+        *outNumLayerRequestMasks = 0;
+        return false;
+    }
+
+    const ReturnData& data = found->second;
+
+    *outNumChangedCompositionTypes = data.compositionTypes.size();
+    *outNumLayerRequestMasks = data.requestMasks.size();
+
+    return !(data.compositionTypes.empty() && data.requestMasks.empty());
+}
+
+void CommandReader::takeChangedCompositionTypes(Display display,
+        std::vector<Layer>* outLayers,
+        std::vector<IComposerClient::Composition>* outTypes)
+{
+    auto found = mReturnData.find(display);
+    if (found == mReturnData.end()) {
+        outLayers->clear();
+        outTypes->clear();
+        return;
+    }
+
+    ReturnData& data = found->second;
+
+    *outLayers = std::move(data.changedLayers);
+    *outTypes = std::move(data.compositionTypes);
+}
+
+void CommandReader::takeDisplayRequests(Display display,
+        uint32_t* outDisplayRequestMask, std::vector<Layer>* outLayers,
+        std::vector<uint32_t>* outLayerRequestMasks)
+{
+    auto found = mReturnData.find(display);
+    if (found == mReturnData.end()) {
+        *outDisplayRequestMask = 0;
+        outLayers->clear();
+        outLayerRequestMasks->clear();
+        return;
+    }
+
+    ReturnData& data = found->second;
+
+    *outDisplayRequestMask = data.displayRequests;
+    *outLayers = std::move(data.requestedLayers);
+    *outLayerRequestMasks = std::move(data.requestMasks);
+}
+
+void CommandReader::takeReleaseFences(Display display,
+        std::vector<Layer>* outLayers, std::vector<int>* outReleaseFences)
+{
+    auto found = mReturnData.find(display);
+    if (found == mReturnData.end()) {
+        outLayers->clear();
+        outReleaseFences->clear();
+        return;
+    }
+
+    ReturnData& data = found->second;
+
+    *outLayers = std::move(data.releasedLayers);
+    *outReleaseFences = std::move(data.releaseFences);
+}
+
+void CommandReader::takePresentFence(Display display, int* outPresentFence)
+{
+    auto found = mReturnData.find(display);
+    if (found == mReturnData.end()) {
+        *outPresentFence = -1;
+        return;
+    }
+
+    ReturnData& data = found->second;
+
+    *outPresentFence = data.presentFence;
+    data.presentFence = -1;
+}
+
+void CommandReader::takePresentOrValidateStage(Display display, uint32_t* state) {
+    auto found = mReturnData.find(display);
+    if (found == mReturnData.end()) {
+        *state= -1;
+        return;
+    }
+    ReturnData& data = found->second;
+    *state = data.presentOrValidateState;
+}
+
+} // namespace Hwc2
+
+} // namespace android

--- a/compat/hwc2/ComposerHal.h
+++ b/compat/hwc2/ComposerHal.h
@@ -1,0 +1,291 @@
+/*
+ * Copyright 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ANDROID_SF_COMPOSER_HAL_H
+#define ANDROID_SF_COMPOSER_HAL_H
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include <android/frameworks/vr/composer/1.0/IVrComposerClient.h>
+#include <android/hardware/graphics/composer/2.1/IComposer.h>
+#include <utils/StrongPointer.h>
+#include <IComposerCommandBuffer.h>
+
+namespace android {
+
+namespace Hwc2 {
+
+using android::frameworks::vr::composer::V1_0::IVrComposerClient;
+
+using android::hardware::graphics::common::V1_0::ColorMode;
+using android::hardware::graphics::common::V1_0::ColorTransform;
+using android::hardware::graphics::common::V1_0::Dataspace;
+using android::hardware::graphics::common::V1_0::Hdr;
+using android::hardware::graphics::common::V1_0::PixelFormat;
+using android::hardware::graphics::common::V1_0::Transform;
+
+using android::hardware::graphics::composer::V2_1::IComposer;
+using android::hardware::graphics::composer::V2_1::IComposerCallback;
+using android::hardware::graphics::composer::V2_1::IComposerClient;
+using android::hardware::graphics::composer::V2_1::Error;
+using android::hardware::graphics::composer::V2_1::Display;
+using android::hardware::graphics::composer::V2_1::Layer;
+using android::hardware::graphics::composer::V2_1::Config;
+
+using android::hardware::graphics::composer::V2_1::CommandWriterBase;
+using android::hardware::graphics::composer::V2_1::CommandReaderBase;
+
+using android::hardware::kSynchronizedReadWrite;
+using android::hardware::MessageQueue;
+using android::hardware::MQDescriptorSync;
+using android::hardware::hidl_vec;
+using android::hardware::hidl_handle;
+
+class CommandReader : public CommandReaderBase {
+public:
+    ~CommandReader();
+
+    // Parse and execute commands from the command queue.  The commands are
+    // actually return values from the server and will be saved in ReturnData.
+    Error parse();
+
+    // Get and clear saved errors.
+    struct CommandError {
+        uint32_t location;
+        Error error;
+    };
+    std::vector<CommandError> takeErrors();
+
+    bool hasChanges(Display display, uint32_t* outNumChangedCompositionTypes,
+            uint32_t* outNumLayerRequestMasks) const;
+
+    // Get and clear saved changed composition types.
+    void takeChangedCompositionTypes(Display display,
+            std::vector<Layer>* outLayers,
+            std::vector<IComposerClient::Composition>* outTypes);
+
+    // Get and clear saved display requests.
+    void takeDisplayRequests(Display display,
+        uint32_t* outDisplayRequestMask, std::vector<Layer>* outLayers,
+        std::vector<uint32_t>* outLayerRequestMasks);
+
+    // Get and clear saved release fences.
+    void takeReleaseFences(Display display, std::vector<Layer>* outLayers,
+            std::vector<int>* outReleaseFences);
+
+    // Get and clear saved present fence.
+    void takePresentFence(Display display, int* outPresentFence);
+
+    // Get what stage succeeded during PresentOrValidate: Present or Validate
+    void takePresentOrValidateStage(Display display, uint32_t * state);
+
+private:
+    void resetData();
+
+    bool parseSelectDisplay(uint16_t length);
+    bool parseSetError(uint16_t length);
+    bool parseSetChangedCompositionTypes(uint16_t length);
+    bool parseSetDisplayRequests(uint16_t length);
+    bool parseSetPresentFence(uint16_t length);
+    bool parseSetReleaseFences(uint16_t length);
+    bool parseSetPresentOrValidateDisplayResult(uint16_t length);
+
+    struct ReturnData {
+        uint32_t displayRequests = 0;
+
+        std::vector<Layer> changedLayers;
+        std::vector<IComposerClient::Composition> compositionTypes;
+
+        std::vector<Layer> requestedLayers;
+        std::vector<uint32_t> requestMasks;
+
+        int presentFence = -1;
+
+        std::vector<Layer> releasedLayers;
+        std::vector<int> releaseFences;
+
+        uint32_t presentOrValidateState;
+    };
+
+    std::vector<CommandError> mErrors;
+    std::unordered_map<Display, ReturnData> mReturnData;
+
+    // When SELECT_DISPLAY is parsed, this is updated to point to the
+    // display's return data in mReturnData.  We use it to avoid repeated
+    // map lookups.
+    ReturnData* mCurrentReturnData;
+};
+
+// Composer is a wrapper to IComposer, a proxy to server-side composer.
+class Composer {
+public:
+    Composer(bool useVrComposer);
+
+    std::vector<IComposer::Capability> getCapabilities();
+    std::string dumpDebugInfo();
+
+    void registerCallback(const sp<IComposerCallback>& callback);
+
+    // Returns true if the connected composer service is running in a remote
+    // process, false otherwise. This will return false if the service is
+    // configured in passthrough mode, for example.
+    bool isRemote();
+
+    // Reset all pending commands in the command buffer. Useful if you want to
+    // skip a frame but have already queued some commands.
+    void resetCommands();
+
+    uint32_t getMaxVirtualDisplayCount();
+    bool isUsingVrComposer() const { return mIsUsingVrComposer; }
+    Error createVirtualDisplay(uint32_t width, uint32_t height,
+            PixelFormat* format, Display* outDisplay);
+    Error destroyVirtualDisplay(Display display);
+
+    Error acceptDisplayChanges(Display display);
+
+    Error createLayer(Display display, Layer* outLayer);
+    Error destroyLayer(Display display, Layer layer);
+
+    Error getActiveConfig(Display display, Config* outConfig);
+    Error getChangedCompositionTypes(Display display,
+            std::vector<Layer>* outLayers,
+            std::vector<IComposerClient::Composition>* outTypes);
+    Error getColorModes(Display display, std::vector<ColorMode>* outModes);
+    Error getDisplayAttribute(Display display, Config config,
+            IComposerClient::Attribute attribute, int32_t* outValue);
+    Error getDisplayConfigs(Display display, std::vector<Config>* outConfigs);
+    Error getDisplayName(Display display, std::string* outName);
+
+    Error getDisplayRequests(Display display, uint32_t* outDisplayRequestMask,
+            std::vector<Layer>* outLayers,
+            std::vector<uint32_t>* outLayerRequestMasks);
+
+    Error getDisplayType(Display display,
+            IComposerClient::DisplayType* outType);
+    Error getDozeSupport(Display display, bool* outSupport);
+    Error getHdrCapabilities(Display display, std::vector<Hdr>* outTypes,
+            float* outMaxLuminance, float* outMaxAverageLuminance,
+            float* outMinLuminance);
+
+    Error getReleaseFences(Display display, std::vector<Layer>* outLayers,
+            std::vector<int>* outReleaseFences);
+
+    Error presentDisplay(Display display, int* outPresentFence);
+
+    Error setActiveConfig(Display display, Config config);
+
+    /*
+     * The composer caches client targets internally.  When target is nullptr,
+     * the composer uses slot to look up the client target from its cache.
+     * When target is not nullptr, the cache is updated with the new target.
+     */
+    Error setClientTarget(Display display, uint32_t slot,
+            const sp<GraphicBuffer>& target,
+            int acquireFence, Dataspace dataspace,
+            const std::vector<IComposerClient::Rect>& damage);
+    Error setColorMode(Display display, ColorMode mode);
+    Error setColorTransform(Display display, const float* matrix,
+            ColorTransform hint);
+    Error setOutputBuffer(Display display, const native_handle_t* buffer,
+            int releaseFence);
+    Error setPowerMode(Display display, IComposerClient::PowerMode mode);
+    Error setVsyncEnabled(Display display, IComposerClient::Vsync enabled);
+
+    Error setClientTargetSlotCount(Display display);
+
+    Error validateDisplay(Display display, uint32_t* outNumTypes,
+            uint32_t* outNumRequests);
+
+    Error presentOrValidateDisplay(Display display, uint32_t* outNumTypes,
+                                   uint32_t* outNumRequests,
+                                   int* outPresentFence,
+                                   uint32_t* state);
+
+    Error setCursorPosition(Display display, Layer layer,
+            int32_t x, int32_t y);
+    /* see setClientTarget for the purpose of slot */
+    Error setLayerBuffer(Display display, Layer layer, uint32_t slot,
+            const sp<GraphicBuffer>& buffer, int acquireFence);
+    Error setLayerSurfaceDamage(Display display, Layer layer,
+            const std::vector<IComposerClient::Rect>& damage);
+    Error setLayerBlendMode(Display display, Layer layer,
+            IComposerClient::BlendMode mode);
+    Error setLayerColor(Display display, Layer layer,
+            const IComposerClient::Color& color);
+    Error setLayerCompositionType(Display display, Layer layer,
+            IComposerClient::Composition type);
+    Error setLayerDataspace(Display display, Layer layer,
+            Dataspace dataspace);
+    Error setLayerDisplayFrame(Display display, Layer layer,
+            const IComposerClient::Rect& frame);
+    Error setLayerPlaneAlpha(Display display, Layer layer,
+            float alpha);
+    Error setLayerSidebandStream(Display display, Layer layer,
+            const native_handle_t* stream);
+    Error setLayerSourceCrop(Display display, Layer layer,
+            const IComposerClient::FRect& crop);
+    Error setLayerTransform(Display display, Layer layer,
+            Transform transform);
+    Error setLayerVisibleRegion(Display display, Layer layer,
+            const std::vector<IComposerClient::Rect>& visible);
+    Error setLayerZOrder(Display display, Layer layer, uint32_t z);
+    Error setLayerInfo(Display display, Layer layer, uint32_t type,
+                       uint32_t appId);
+private:
+    class CommandWriter : public CommandWriterBase {
+    public:
+        CommandWriter(uint32_t initialMaxSize);
+        ~CommandWriter() override;
+
+        void setLayerInfo(uint32_t type, uint32_t appId);
+        void setClientTargetMetadata(
+                const IVrComposerClient::BufferMetadata& metadata);
+        void setLayerBufferMetadata(
+                const IVrComposerClient::BufferMetadata& metadata);
+
+    private:
+        void writeBufferMetadata(
+                const IVrComposerClient::BufferMetadata& metadata);
+    };
+
+    // Many public functions above simply write a command into the command
+    // queue to batch the calls.  validateDisplay and presentDisplay will call
+    // this function to execute the command queue.
+    Error execute();
+
+    sp<IComposer> mComposer;
+    sp<IComposerClient> mClient;
+
+    // 64KiB minus a small space for metadata such as read/write pointers
+    static constexpr size_t kWriterInitialSize =
+        64 * 1024 / sizeof(uint32_t) - 16;
+    CommandWriter mWriter;
+    CommandReader mReader;
+
+    // When true, the we attach to the vr_hwcomposer service instead of the
+    // hwcomposer. This allows us to redirect surfaces to 3d surfaces in vr.
+    const bool mIsUsingVrComposer;
+};
+
+} // namespace Hwc2
+
+} // namespace android
+
+#endif // ANDROID_SF_COMPOSER_HAL_H

--- a/compat/hwc2/HWC2.cpp
+++ b/compat/hwc2/HWC2.cpp
@@ -1,0 +1,879 @@
+/*
+ * Copyright 2015 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// #define LOG_NDEBUG 0
+
+#undef LOG_TAG
+#define LOG_TAG "HWC2"
+#define ATRACE_TAG ATRACE_TAG_GRAPHICS
+
+#include "HWC2.h"
+#include "ComposerHal.h"
+
+#include <ui/Fence.h>
+#include <ui/FloatRect.h>
+#include <ui/GraphicBuffer.h>
+#include <ui/Region.h>
+
+#include <android/configuration.h>
+
+#include <algorithm>
+#include <inttypes.h>
+
+using android::Fence;
+using android::FloatRect;
+using android::GraphicBuffer;
+using android::HdrCapabilities;
+using android::Rect;
+using android::Region;
+using android::sp;
+using android::hardware::Return;
+using android::hardware::Void;
+
+namespace HWC2 {
+
+namespace Hwc2 = android::Hwc2;
+
+namespace {
+
+class ComposerCallbackBridge : public Hwc2::IComposerCallback {
+public:
+    ComposerCallbackBridge(ComposerCallback* callback, int32_t sequenceId)
+            : mCallback(callback), mSequenceId(sequenceId),
+              mHasPrimaryDisplay(false) {}
+
+    Return<void> onHotplug(Hwc2::Display display,
+                           IComposerCallback::Connection conn) override
+    {
+        HWC2::Connection connection = static_cast<HWC2::Connection>(conn);
+        if (!mHasPrimaryDisplay) {
+            LOG_ALWAYS_FATAL_IF(connection != HWC2::Connection::Connected,
+                    "Initial onHotplug callback should be "
+                    "primary display connected");
+            mHasPrimaryDisplay = true;
+            mCallback->onHotplugReceived(mSequenceId, display,
+                                         connection, true);
+        } else {
+            mCallback->onHotplugReceived(mSequenceId, display,
+                                         connection, false);
+        }
+        return Void();
+    }
+
+    Return<void> onRefresh(Hwc2::Display display) override
+    {
+        mCallback->onRefreshReceived(mSequenceId, display);
+        return Void();
+    }
+
+    Return<void> onVsync(Hwc2::Display display, int64_t timestamp) override
+    {
+        mCallback->onVsyncReceived(mSequenceId, display, timestamp);
+        return Void();
+    }
+
+    bool HasPrimaryDisplay() { return mHasPrimaryDisplay; }
+
+private:
+    ComposerCallback* mCallback;
+    int32_t mSequenceId;
+    bool mHasPrimaryDisplay;
+};
+
+} // namespace anonymous
+
+
+// Device methods
+
+Device::Device(bool useVrComposer)
+  : mComposer(std::make_unique<Hwc2::Composer>(useVrComposer)),
+    mCapabilities(),
+    mDisplays(),
+    mRegisteredCallback(false)
+{
+    loadCapabilities();
+}
+
+void Device::registerCallback(ComposerCallback* callback, int32_t sequenceId) {
+    if (mRegisteredCallback) {
+        ALOGW("Callback already registered. Ignored extra registration "
+                "attempt.");
+        return;
+    }
+    mRegisteredCallback = true;
+    sp<ComposerCallbackBridge> callbackBridge(
+            new ComposerCallbackBridge(callback, sequenceId));
+    mComposer->registerCallback(callbackBridge);
+    LOG_ALWAYS_FATAL_IF(!callbackBridge->HasPrimaryDisplay(),
+            "Registered composer callback but didn't get primary display");
+}
+
+// Required by HWC2 device
+
+std::string Device::dump() const
+{
+    return mComposer->dumpDebugInfo();
+}
+
+uint32_t Device::getMaxVirtualDisplayCount() const
+{
+    return mComposer->getMaxVirtualDisplayCount();
+}
+
+Error Device::createVirtualDisplay(uint32_t width, uint32_t height,
+        android_pixel_format_t* format, Display** outDisplay)
+{
+    ALOGI("Creating virtual display");
+
+    hwc2_display_t displayId = 0;
+    auto intFormat = static_cast<Hwc2::PixelFormat>(*format);
+    auto intError = mComposer->createVirtualDisplay(width, height,
+            &intFormat, &displayId);
+    auto error = static_cast<Error>(intError);
+    if (error != Error::None) {
+        return error;
+    }
+
+    auto display = std::make_unique<Display>(
+            *mComposer.get(), mCapabilities, displayId, DisplayType::Virtual);
+    *outDisplay = display.get();
+    *format = static_cast<android_pixel_format_t>(intFormat);
+    mDisplays.emplace(displayId, std::move(display));
+    ALOGI("Created virtual display");
+    return Error::None;
+}
+
+void Device::destroyDisplay(hwc2_display_t displayId)
+{
+    ALOGI("Destroying display %" PRIu64, displayId);
+    mDisplays.erase(displayId);
+}
+
+void Device::onHotplug(hwc2_display_t displayId, Connection connection) {
+    if (connection == Connection::Connected) {
+        auto display = getDisplayById(displayId);
+        if (display) {
+            if (display->isConnected()) {
+                ALOGW("Attempt to hotplug connect display %" PRIu64
+                        " , which is already connected.", displayId);
+            } else {
+                display->setConnected(true);
+            }
+        } else {
+            DisplayType displayType;
+            auto intError = mComposer->getDisplayType(displayId,
+                    reinterpret_cast<Hwc2::IComposerClient::DisplayType *>(
+                            &displayType));
+            auto error = static_cast<Error>(intError);
+            if (error != Error::None) {
+                ALOGE("getDisplayType(%" PRIu64 ") failed: %s (%d). "
+                        "Aborting hotplug attempt.",
+                        displayId, to_string(error).c_str(), intError);
+                return;
+            }
+
+            auto newDisplay = std::make_unique<Display>(
+                    *mComposer.get(), mCapabilities, displayId, displayType);
+            mDisplays.emplace(displayId, std::move(newDisplay));
+        }
+    } else if (connection == Connection::Disconnected) {
+        // The display will later be destroyed by a call to
+        // destroyDisplay(). For now we just mark it disconnected.
+        auto display = getDisplayById(displayId);
+        if (display) {
+            display->setConnected(false);
+        } else {
+            ALOGW("Attempted to disconnect unknown display %" PRIu64,
+                  displayId);
+        }
+    }
+}
+
+// Other Device methods
+
+Display* Device::getDisplayById(hwc2_display_t id) {
+    auto iter = mDisplays.find(id);
+    return iter == mDisplays.end() ? nullptr : iter->second.get();
+}
+
+// Device initialization methods
+
+void Device::loadCapabilities()
+{
+    static_assert(sizeof(Capability) == sizeof(int32_t),
+            "Capability size has changed");
+    auto capabilities = mComposer->getCapabilities();
+    for (auto capability : capabilities) {
+        mCapabilities.emplace(static_cast<Capability>(capability));
+    }
+}
+
+// Display methods
+
+Display::Display(android::Hwc2::Composer& composer,
+                 const std::unordered_set<Capability>& capabilities,
+                 hwc2_display_t id, DisplayType type)
+  : mComposer(composer),
+    mCapabilities(capabilities),
+    mId(id),
+    mIsConnected(false),
+    mType(type)
+{
+    ALOGV("Created display %" PRIu64, id);
+    setConnected(true);
+}
+
+Display::~Display() {
+    mLayers.clear();
+
+    if (mType == DisplayType::Virtual) {
+        ALOGV("Destroying virtual display");
+        auto intError = mComposer.destroyVirtualDisplay(mId);
+        auto error = static_cast<Error>(intError);
+        ALOGE_IF(error != Error::None, "destroyVirtualDisplay(%" PRIu64
+                ") failed: %s (%d)", mId, to_string(error).c_str(), intError);
+    } else if (mType == DisplayType::Physical) {
+        auto error = setVsyncEnabled(HWC2::Vsync::Disable);
+        if (error != Error::None) {
+            ALOGE("~Display: Failed to disable vsync for display %" PRIu64
+                    ": %s (%d)", mId, to_string(error).c_str(),
+                    static_cast<int32_t>(error));
+        }
+    }
+}
+
+Display::Config::Config(Display& display, hwc2_config_t id)
+  : mDisplay(display),
+    mId(id),
+    mWidth(-1),
+    mHeight(-1),
+    mVsyncPeriod(-1),
+    mDpiX(-1),
+    mDpiY(-1) {}
+
+Display::Config::Builder::Builder(Display& display, hwc2_config_t id)
+  : mConfig(new Config(display, id)) {}
+
+float Display::Config::Builder::getDefaultDensity() {
+    // Default density is based on TVs: 1080p displays get XHIGH density, lower-
+    // resolution displays get TV density. Maybe eventually we'll need to update
+    // it for 4k displays, though hopefully those will just report accurate DPI
+    // information to begin with. This is also used for virtual displays and
+    // older HWC implementations, so be careful about orientation.
+
+    auto longDimension = std::max(mConfig->mWidth, mConfig->mHeight);
+    if (longDimension >= 1080) {
+        return ACONFIGURATION_DENSITY_XHIGH;
+    } else {
+        return ACONFIGURATION_DENSITY_TV;
+    }
+}
+
+// Required by HWC2 display
+
+Error Display::acceptChanges()
+{
+    auto intError = mComposer.acceptDisplayChanges(mId);
+    return static_cast<Error>(intError);
+}
+
+Error Display::createLayer(Layer** outLayer)
+{
+    if (!outLayer) {
+        return Error::BadParameter;
+    }
+    hwc2_layer_t layerId = 0;
+    auto intError = mComposer.createLayer(mId, &layerId);
+    auto error = static_cast<Error>(intError);
+    if (error != Error::None) {
+        return error;
+    }
+
+    auto layer = std::make_unique<Layer>(
+            mComposer, mCapabilities, mId, layerId);
+    *outLayer = layer.get();
+    mLayers.emplace(layerId, std::move(layer));
+    return Error::None;
+}
+
+Error Display::destroyLayer(Layer* layer)
+{
+    if (!layer) {
+        return Error::BadParameter;
+    }
+    mLayers.erase(layer->getId());
+    return Error::None;
+}
+
+Error Display::getActiveConfig(
+        std::shared_ptr<const Display::Config>* outConfig) const
+{
+    ALOGV("[%" PRIu64 "] getActiveConfig", mId);
+    hwc2_config_t configId = 0;
+    auto intError = mComposer.getActiveConfig(mId, &configId);
+    auto error = static_cast<Error>(intError);
+
+    if (error != Error::None) {
+        ALOGE("Unable to get active config for mId:[%" PRIu64 "]", mId);
+        *outConfig = nullptr;
+        return error;
+    }
+
+    if (mConfigs.count(configId) != 0) {
+        *outConfig = mConfigs.at(configId);
+    } else {
+        ALOGE("[%" PRIu64 "] getActiveConfig returned unknown config %u", mId,
+                configId);
+        // Return no error, but the caller needs to check for a null pointer to
+        // detect this case
+        *outConfig = nullptr;
+    }
+
+    return Error::None;
+}
+
+Error Display::getChangedCompositionTypes(
+        std::unordered_map<Layer*, Composition>* outTypes)
+{
+    std::vector<Hwc2::Layer> layerIds;
+    std::vector<Hwc2::IComposerClient::Composition> types;
+    auto intError = mComposer.getChangedCompositionTypes(
+            mId, &layerIds, &types);
+    uint32_t numElements = layerIds.size();
+    auto error = static_cast<Error>(intError);
+    error = static_cast<Error>(intError);
+    if (error != Error::None) {
+        return error;
+    }
+
+    outTypes->clear();
+    outTypes->reserve(numElements);
+    for (uint32_t element = 0; element < numElements; ++element) {
+        auto layer = getLayerById(layerIds[element]);
+        if (layer) {
+            auto type = static_cast<Composition>(types[element]);
+            ALOGV("getChangedCompositionTypes: adding %" PRIu64 " %s",
+                    layer->getId(), to_string(type).c_str());
+            outTypes->emplace(layer, type);
+        } else {
+            ALOGE("getChangedCompositionTypes: invalid layer %" PRIu64 " found"
+                    " on display %" PRIu64, layerIds[element], mId);
+        }
+    }
+
+    return Error::None;
+}
+
+Error Display::getColorModes(std::vector<android_color_mode_t>* outModes) const
+{
+    std::vector<Hwc2::ColorMode> modes;
+    auto intError = mComposer.getColorModes(mId, &modes);
+    uint32_t numModes = modes.size();
+    auto error = static_cast<Error>(intError);
+    if (error != Error::None) {
+        return error;
+    }
+
+    outModes->resize(numModes);
+    for (size_t i = 0; i < numModes; i++) {
+        (*outModes)[i] = static_cast<android_color_mode_t>(modes[i]);
+    }
+    return Error::None;
+}
+
+std::vector<std::shared_ptr<const Display::Config>> Display::getConfigs() const
+{
+    std::vector<std::shared_ptr<const Config>> configs;
+    for (const auto& element : mConfigs) {
+        configs.emplace_back(element.second);
+    }
+    return configs;
+}
+
+Error Display::getName(std::string* outName) const
+{
+    auto intError = mComposer.getDisplayName(mId, outName);
+    return static_cast<Error>(intError);
+}
+
+Error Display::getRequests(HWC2::DisplayRequest* outDisplayRequests,
+        std::unordered_map<Layer*, LayerRequest>* outLayerRequests)
+{
+    uint32_t intDisplayRequests;
+    std::vector<Hwc2::Layer> layerIds;
+    std::vector<uint32_t> layerRequests;
+    auto intError = mComposer.getDisplayRequests(
+            mId, &intDisplayRequests, &layerIds, &layerRequests);
+    uint32_t numElements = layerIds.size();
+    auto error = static_cast<Error>(intError);
+    if (error != Error::None) {
+        return error;
+    }
+
+    *outDisplayRequests = static_cast<DisplayRequest>(intDisplayRequests);
+    outLayerRequests->clear();
+    outLayerRequests->reserve(numElements);
+    for (uint32_t element = 0; element < numElements; ++element) {
+        auto layer = getLayerById(layerIds[element]);
+        if (layer) {
+            auto layerRequest =
+                    static_cast<LayerRequest>(layerRequests[element]);
+            outLayerRequests->emplace(layer, layerRequest);
+        } else {
+            ALOGE("getRequests: invalid layer %" PRIu64 " found on display %"
+                    PRIu64, layerIds[element], mId);
+        }
+    }
+
+    return Error::None;
+}
+
+Error Display::getType(DisplayType* outType) const
+{
+    *outType = mType;
+    return Error::None;
+}
+
+Error Display::supportsDoze(bool* outSupport) const
+{
+    bool intSupport = false;
+    auto intError = mComposer.getDozeSupport(mId, &intSupport);
+    auto error = static_cast<Error>(intError);
+    if (error != Error::None) {
+        return error;
+    }
+    *outSupport = static_cast<bool>(intSupport);
+    return Error::None;
+}
+
+Error Display::getHdrCapabilities(
+        std::unique_ptr<HdrCapabilities>* outCapabilities) const
+{
+    uint32_t numTypes = 0;
+    float maxLuminance = -1.0f;
+    float maxAverageLuminance = -1.0f;
+    float minLuminance = -1.0f;
+    std::vector<Hwc2::Hdr> intTypes;
+    auto intError = mComposer.getHdrCapabilities(mId, &intTypes,
+            &maxLuminance, &maxAverageLuminance, &minLuminance);
+    auto error = static_cast<HWC2::Error>(intError);
+
+    std::vector<int32_t> types;
+    for (auto type : intTypes) {
+        types.push_back(static_cast<int32_t>(type));
+    }
+    numTypes = types.size();
+    if (error != Error::None) {
+        return error;
+    }
+
+    *outCapabilities = std::make_unique<HdrCapabilities>(std::move(types),
+            maxLuminance, maxAverageLuminance, minLuminance);
+    return Error::None;
+}
+
+Error Display::getReleaseFences(
+        std::unordered_map<Layer*, sp<Fence>>* outFences) const
+{
+    std::vector<Hwc2::Layer> layerIds;
+    std::vector<int> fenceFds;
+    auto intError = mComposer.getReleaseFences(mId, &layerIds, &fenceFds);
+    auto error = static_cast<Error>(intError);
+    uint32_t numElements = layerIds.size();
+    if (error != Error::None) {
+        return error;
+    }
+
+    std::unordered_map<Layer*, sp<Fence>> releaseFences;
+    releaseFences.reserve(numElements);
+    for (uint32_t element = 0; element < numElements; ++element) {
+        auto layer = getLayerById(layerIds[element]);
+        if (layer) {
+            sp<Fence> fence(new Fence(fenceFds[element]));
+            releaseFences.emplace(layer, fence);
+        } else {
+            ALOGE("getReleaseFences: invalid layer %" PRIu64
+                    " found on display %" PRIu64, layerIds[element], mId);
+            for (; element < numElements; ++element) {
+                close(fenceFds[element]);
+            }
+            return Error::BadLayer;
+        }
+    }
+
+    *outFences = std::move(releaseFences);
+    return Error::None;
+}
+
+Error Display::present(sp<Fence>* outPresentFence)
+{
+    int32_t presentFenceFd = -1;
+    auto intError = mComposer.presentDisplay(mId, &presentFenceFd);
+    auto error = static_cast<Error>(intError);
+    if (error != Error::None) {
+        return error;
+    }
+
+    *outPresentFence = new Fence(presentFenceFd);
+    return Error::None;
+}
+
+Error Display::setActiveConfig(const std::shared_ptr<const Config>& config)
+{
+    if (config->getDisplayId() != mId) {
+        ALOGE("setActiveConfig received config %u for the wrong display %"
+                PRIu64 " (expected %" PRIu64 ")", config->getId(),
+                config->getDisplayId(), mId);
+        return Error::BadConfig;
+    }
+    auto intError = mComposer.setActiveConfig(mId, config->getId());
+    return static_cast<Error>(intError);
+}
+
+Error Display::setClientTarget(uint32_t slot, const sp<GraphicBuffer>& target,
+        const sp<Fence>& acquireFence, android_dataspace_t dataspace)
+{
+    // TODO: Properly encode client target surface damage
+    int32_t fenceFd = acquireFence->dup();
+    auto intError = mComposer.setClientTarget(mId, slot, target,
+            fenceFd, static_cast<Hwc2::Dataspace>(dataspace),
+            std::vector<Hwc2::IComposerClient::Rect>());
+    return static_cast<Error>(intError);
+}
+
+Error Display::setColorMode(android_color_mode_t mode)
+{
+    auto intError = mComposer.setColorMode(
+            mId, static_cast<Hwc2::ColorMode>(mode));
+    return static_cast<Error>(intError);
+}
+
+Error Display::setColorTransform(const android::mat4& matrix,
+        android_color_transform_t hint)
+{
+    auto intError = mComposer.setColorTransform(mId,
+            matrix.asArray(), static_cast<Hwc2::ColorTransform>(hint));
+    return static_cast<Error>(intError);
+}
+
+Error Display::setOutputBuffer(const sp<GraphicBuffer>& buffer,
+        const sp<Fence>& releaseFence)
+{
+    int32_t fenceFd = releaseFence->dup();
+    auto handle = buffer->getNativeBuffer()->handle;
+    auto intError = mComposer.setOutputBuffer(mId, handle, fenceFd);
+    close(fenceFd);
+    return static_cast<Error>(intError);
+}
+
+Error Display::setPowerMode(PowerMode mode)
+{
+    auto intMode = static_cast<Hwc2::IComposerClient::PowerMode>(mode);
+    auto intError = mComposer.setPowerMode(mId, intMode);
+    return static_cast<Error>(intError);
+}
+
+Error Display::setVsyncEnabled(Vsync enabled)
+{
+    auto intEnabled = static_cast<Hwc2::IComposerClient::Vsync>(enabled);
+    auto intError = mComposer.setVsyncEnabled(mId, intEnabled);
+    return static_cast<Error>(intError);
+}
+
+Error Display::validate(uint32_t* outNumTypes, uint32_t* outNumRequests)
+{
+    uint32_t numTypes = 0;
+    uint32_t numRequests = 0;
+    auto intError = mComposer.validateDisplay(mId, &numTypes, &numRequests);
+    auto error = static_cast<Error>(intError);
+    if (error != Error::None && error != Error::HasChanges) {
+        return error;
+    }
+
+    *outNumTypes = numTypes;
+    *outNumRequests = numRequests;
+    return error;
+}
+
+Error Display::presentOrValidate(uint32_t* outNumTypes, uint32_t* outNumRequests,
+                                 sp<android::Fence>* outPresentFence, uint32_t* state) {
+
+    uint32_t numTypes = 0;
+    uint32_t numRequests = 0;
+    int32_t presentFenceFd = -1;
+    auto intError = mComposer.presentOrValidateDisplay(
+            mId, &numTypes, &numRequests, &presentFenceFd, state);
+    auto error = static_cast<Error>(intError);
+    if (error != Error::None && error != Error::HasChanges) {
+        return error;
+    }
+
+    if (*state == 1) {
+        *outPresentFence = new Fence(presentFenceFd);
+    }
+
+    if (*state == 0) {
+        *outNumTypes = numTypes;
+        *outNumRequests = numRequests;
+    }
+    return error;
+}
+
+void Display::discardCommands()
+{
+    mComposer.resetCommands();
+}
+
+// For use by Device
+
+void Display::setConnected(bool connected) {
+    if (!mIsConnected && connected && mType == DisplayType::Physical) {
+        mComposer.setClientTargetSlotCount(mId);
+        loadConfigs();
+    }
+    mIsConnected = connected;
+}
+
+int32_t Display::getAttribute(hwc2_config_t configId, Attribute attribute)
+{
+    int32_t value = 0;
+    auto intError = mComposer.getDisplayAttribute(mId, configId,
+            static_cast<Hwc2::IComposerClient::Attribute>(attribute),
+            &value);
+    auto error = static_cast<Error>(intError);
+    if (error != Error::None) {
+        ALOGE("getDisplayAttribute(%" PRIu64 ", %u, %s) failed: %s (%d)", mId,
+                configId, to_string(attribute).c_str(),
+                to_string(error).c_str(), intError);
+        return -1;
+    }
+    return value;
+}
+
+void Display::loadConfig(hwc2_config_t configId)
+{
+    ALOGV("[%" PRIu64 "] loadConfig(%u)", mId, configId);
+
+    auto config = Config::Builder(*this, configId)
+            .setWidth(getAttribute(configId, Attribute::Width))
+            .setHeight(getAttribute(configId, Attribute::Height))
+            .setVsyncPeriod(getAttribute(configId, Attribute::VsyncPeriod))
+            .setDpiX(getAttribute(configId, Attribute::DpiX))
+            .setDpiY(getAttribute(configId, Attribute::DpiY))
+            .build();
+    mConfigs.emplace(configId, std::move(config));
+}
+
+void Display::loadConfigs()
+{
+    ALOGV("[%" PRIu64 "] loadConfigs", mId);
+
+    std::vector<Hwc2::Config> configIds;
+    auto intError = mComposer.getDisplayConfigs(mId, &configIds);
+    auto error = static_cast<Error>(intError);
+    if (error != Error::None) {
+        ALOGE("[%" PRIu64 "] getDisplayConfigs [2] failed: %s (%d)", mId,
+                to_string(error).c_str(), intError);
+        return;
+    }
+
+    for (auto configId : configIds) {
+        loadConfig(configId);
+    }
+}
+
+// Other Display methods
+
+Layer* Display::getLayerById(hwc2_layer_t id) const
+{
+    if (mLayers.count(id) == 0) {
+        return nullptr;
+    }
+
+    return mLayers.at(id).get();
+}
+
+// Layer methods
+
+Layer::Layer(android::Hwc2::Composer& composer,
+             const std::unordered_set<Capability>& capabilities,
+             hwc2_display_t displayId, hwc2_layer_t layerId)
+  : mComposer(composer),
+    mCapabilities(capabilities),
+    mDisplayId(displayId),
+    mId(layerId)
+{
+    ALOGV("Created layer %" PRIu64 " on display %" PRIu64, layerId, displayId);
+}
+
+Layer::~Layer()
+{
+    auto intError = mComposer.destroyLayer(mDisplayId, mId);
+    auto error = static_cast<Error>(intError);
+    ALOGE_IF(error != Error::None, "destroyLayer(%" PRIu64 ", %" PRIu64 ")"
+            " failed: %s (%d)", mDisplayId, mId, to_string(error).c_str(),
+            intError);
+    if (mLayerDestroyedListener) {
+        mLayerDestroyedListener(this);
+    }
+}
+
+void Layer::setLayerDestroyedListener(std::function<void(Layer*)> listener) {
+    LOG_ALWAYS_FATAL_IF(mLayerDestroyedListener && listener,
+            "Attempt to set layer destroyed listener multiple times");
+    mLayerDestroyedListener = listener;
+}
+
+Error Layer::setCursorPosition(int32_t x, int32_t y)
+{
+    auto intError = mComposer.setCursorPosition(mDisplayId, mId, x, y);
+    return static_cast<Error>(intError);
+}
+
+Error Layer::setBuffer(uint32_t slot, const sp<GraphicBuffer>& buffer,
+        const sp<Fence>& acquireFence)
+{
+    int32_t fenceFd = acquireFence->dup();
+    auto intError = mComposer.setLayerBuffer(mDisplayId, mId, slot, buffer,
+                                             fenceFd);
+    return static_cast<Error>(intError);
+}
+
+Error Layer::setSurfaceDamage(const Region& damage)
+{
+    // We encode default full-screen damage as INVALID_RECT upstream, but as 0
+    // rects for HWC
+    Hwc2::Error intError = Hwc2::Error::NONE;
+    if (damage.isRect() && damage.getBounds() == Rect::INVALID_RECT) {
+        intError = mComposer.setLayerSurfaceDamage(mDisplayId,
+                mId, std::vector<Hwc2::IComposerClient::Rect>());
+    } else {
+        size_t rectCount = 0;
+        auto rectArray = damage.getArray(&rectCount);
+
+        std::vector<Hwc2::IComposerClient::Rect> hwcRects;
+        for (size_t rect = 0; rect < rectCount; ++rect) {
+            hwcRects.push_back({rectArray[rect].left, rectArray[rect].top,
+                    rectArray[rect].right, rectArray[rect].bottom});
+        }
+
+        intError = mComposer.setLayerSurfaceDamage(mDisplayId, mId, hwcRects);
+    }
+
+    return static_cast<Error>(intError);
+}
+
+Error Layer::setBlendMode(BlendMode mode)
+{
+    auto intMode = static_cast<Hwc2::IComposerClient::BlendMode>(mode);
+    auto intError = mComposer.setLayerBlendMode(mDisplayId, mId, intMode);
+    return static_cast<Error>(intError);
+}
+
+Error Layer::setColor(hwc_color_t color)
+{
+    Hwc2::IComposerClient::Color hwcColor{color.r, color.g, color.b, color.a};
+    auto intError = mComposer.setLayerColor(mDisplayId, mId, hwcColor);
+    return static_cast<Error>(intError);
+}
+
+Error Layer::setCompositionType(Composition type)
+{
+    auto intType = static_cast<Hwc2::IComposerClient::Composition>(type);
+    auto intError = mComposer.setLayerCompositionType(
+            mDisplayId, mId, intType);
+    return static_cast<Error>(intError);
+}
+
+Error Layer::setDataspace(android_dataspace_t dataspace)
+{
+    if (dataspace == mDataSpace) {
+        return Error::None;
+    }
+    mDataSpace = dataspace;
+    auto intDataspace = static_cast<Hwc2::Dataspace>(dataspace);
+    auto intError = mComposer.setLayerDataspace(mDisplayId, mId, intDataspace);
+    return static_cast<Error>(intError);
+}
+
+Error Layer::setDisplayFrame(const Rect& frame)
+{
+    Hwc2::IComposerClient::Rect hwcRect{frame.left, frame.top,
+        frame.right, frame.bottom};
+    auto intError = mComposer.setLayerDisplayFrame(mDisplayId, mId, hwcRect);
+    return static_cast<Error>(intError);
+}
+
+Error Layer::setPlaneAlpha(float alpha)
+{
+    auto intError = mComposer.setLayerPlaneAlpha(mDisplayId, mId, alpha);
+    return static_cast<Error>(intError);
+}
+
+Error Layer::setSidebandStream(const native_handle_t* stream)
+{
+    if (mCapabilities.count(Capability::SidebandStream) == 0) {
+        ALOGE("Attempted to call setSidebandStream without checking that the "
+                "device supports sideband streams");
+        return Error::Unsupported;
+    }
+    auto intError = mComposer.setLayerSidebandStream(mDisplayId, mId, stream);
+    return static_cast<Error>(intError);
+}
+
+Error Layer::setSourceCrop(const FloatRect& crop)
+{
+    Hwc2::IComposerClient::FRect hwcRect{
+        crop.left, crop.top, crop.right, crop.bottom};
+    auto intError = mComposer.setLayerSourceCrop(mDisplayId, mId, hwcRect);
+    return static_cast<Error>(intError);
+}
+
+Error Layer::setTransform(Transform transform)
+{
+    auto intTransform = static_cast<Hwc2::Transform>(transform);
+    auto intError = mComposer.setLayerTransform(mDisplayId, mId, intTransform);
+    return static_cast<Error>(intError);
+}
+
+Error Layer::setVisibleRegion(const Region& region)
+{
+    size_t rectCount = 0;
+    auto rectArray = region.getArray(&rectCount);
+
+    std::vector<Hwc2::IComposerClient::Rect> hwcRects;
+    for (size_t rect = 0; rect < rectCount; ++rect) {
+        hwcRects.push_back({rectArray[rect].left, rectArray[rect].top,
+                rectArray[rect].right, rectArray[rect].bottom});
+    }
+
+    auto intError = mComposer.setLayerVisibleRegion(mDisplayId, mId, hwcRects);
+    return static_cast<Error>(intError);
+}
+
+Error Layer::setZOrder(uint32_t z)
+{
+    auto intError = mComposer.setLayerZOrder(mDisplayId, mId, z);
+    return static_cast<Error>(intError);
+}
+
+Error Layer::setInfo(uint32_t type, uint32_t appId)
+{
+  auto intError = mComposer.setLayerInfo(mDisplayId, mId, type, appId);
+  return static_cast<Error>(intError);
+}
+
+} // namespace HWC2

--- a/compat/hwc2/HWC2.h
+++ b/compat/hwc2/HWC2.h
@@ -1,0 +1,342 @@
+/*
+ * Copyright 2015 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ANDROID_SF_HWC2_H
+#define ANDROID_SF_HWC2_H
+
+#define HWC2_INCLUDE_STRINGIFICATION
+#define HWC2_USE_CPP11
+#include <hardware/hwcomposer2.h>
+#undef HWC2_INCLUDE_STRINGIFICATION
+#undef HWC2_USE_CPP11
+
+#include <ui/HdrCapabilities.h>
+#include <math/mat4.h>
+
+#include <utils/Log.h>
+#include <utils/StrongPointer.h>
+#include <utils/Timers.h>
+
+#include <functional>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+#include <map>
+
+namespace android {
+    class Fence;
+    class FloatRect;
+    class GraphicBuffer;
+    class Rect;
+    class Region;
+    namespace Hwc2 {
+        class Composer;
+    }
+}
+
+namespace HWC2 {
+
+class Display;
+class Layer;
+
+// Implement this interface to receive hardware composer events.
+//
+// These callback functions will generally be called on a hwbinder thread, but
+// when first registering the callback the onHotplugReceived() function will
+// immediately be called on the thread calling registerCallback().
+//
+// All calls receive a sequenceId, which will be the value that was supplied to
+// HWC2::Device::registerCallback(). It's used to help differentiate callbacks
+// from different hardware composer instances.
+class ComposerCallback {
+ public:
+    virtual void onHotplugReceived(int32_t sequenceId, hwc2_display_t display,
+                                   Connection connection,
+                                   bool primaryDisplay) = 0;
+    virtual void onRefreshReceived(int32_t sequenceId,
+                                   hwc2_display_t display) = 0;
+    virtual void onVsyncReceived(int32_t sequenceId, hwc2_display_t display,
+                                 int64_t timestamp) = 0;
+    virtual ~ComposerCallback() = default;
+};
+
+// C++ Wrapper around hwc2_device_t. Load all functions pointers
+// and handle callback registration.
+class Device
+{
+public:
+    // useVrComposer is passed to the composer HAL. When true, the composer HAL
+    // will use the vr composer service, otherwise it uses the real hardware
+    // composer.
+    Device(bool useVrComposer);
+
+    void registerCallback(ComposerCallback* callback, int32_t sequenceId);
+
+    // Required by HWC2
+
+    std::string dump() const;
+
+    const std::unordered_set<Capability>& getCapabilities() const {
+        return mCapabilities;
+    };
+
+    uint32_t getMaxVirtualDisplayCount() const;
+    Error createVirtualDisplay(uint32_t width, uint32_t height,
+            android_pixel_format_t* format, Display** outDisplay);
+    void destroyDisplay(hwc2_display_t displayId);
+
+    void onHotplug(hwc2_display_t displayId, Connection connection);
+
+    // Other Device methods
+
+    Display* getDisplayById(hwc2_display_t id);
+
+    android::Hwc2::Composer* getComposer() { return mComposer.get(); }
+
+private:
+    // Initialization methods
+
+    void loadCapabilities();
+
+    // Member variables
+    std::unique_ptr<android::Hwc2::Composer> mComposer;
+    std::unordered_set<Capability> mCapabilities;
+    std::unordered_map<hwc2_display_t, std::unique_ptr<Display>> mDisplays;
+    bool mRegisteredCallback;
+};
+
+// Convenience C++ class to access hwc2_device_t Display functions directly.
+class Display
+{
+public:
+    Display(android::Hwc2::Composer& composer,
+            const std::unordered_set<Capability>& capabilities,
+            hwc2_display_t id, DisplayType type);
+    ~Display();
+
+    class Config
+    {
+    public:
+        class Builder
+        {
+        public:
+            Builder(Display& display, hwc2_config_t id);
+
+            std::shared_ptr<const Config> build() {
+                return std::const_pointer_cast<const Config>(
+                        std::move(mConfig));
+            }
+
+            Builder& setWidth(int32_t width) {
+                mConfig->mWidth = width;
+                return *this;
+            }
+            Builder& setHeight(int32_t height) {
+                mConfig->mHeight = height;
+                return *this;
+            }
+            Builder& setVsyncPeriod(int32_t vsyncPeriod) {
+                mConfig->mVsyncPeriod = vsyncPeriod;
+                return *this;
+            }
+            Builder& setDpiX(int32_t dpiX) {
+                if (dpiX == -1) {
+                    mConfig->mDpiX = getDefaultDensity();
+                } else {
+                    mConfig->mDpiX = dpiX / 1000.0f;
+                }
+                return *this;
+            }
+            Builder& setDpiY(int32_t dpiY) {
+                if (dpiY == -1) {
+                    mConfig->mDpiY = getDefaultDensity();
+                } else {
+                    mConfig->mDpiY = dpiY / 1000.0f;
+                }
+                return *this;
+            }
+
+        private:
+            float getDefaultDensity();
+            std::shared_ptr<Config> mConfig;
+        };
+
+        hwc2_display_t getDisplayId() const { return mDisplay.getId(); }
+        hwc2_config_t getId() const { return mId; }
+
+        int32_t getWidth() const { return mWidth; }
+        int32_t getHeight() const { return mHeight; }
+        nsecs_t getVsyncPeriod() const { return mVsyncPeriod; }
+        float getDpiX() const { return mDpiX; }
+        float getDpiY() const { return mDpiY; }
+
+    private:
+        Config(Display& display, hwc2_config_t id);
+
+        Display& mDisplay;
+        hwc2_config_t mId;
+
+        int32_t mWidth;
+        int32_t mHeight;
+        nsecs_t mVsyncPeriod;
+        float mDpiX;
+        float mDpiY;
+    };
+
+    // Required by HWC2
+
+    [[clang::warn_unused_result]] Error acceptChanges();
+    [[clang::warn_unused_result]] Error createLayer(Layer** outLayer);
+    [[clang::warn_unused_result]] Error destroyLayer(Layer* layer);
+    [[clang::warn_unused_result]] Error getActiveConfig(
+            std::shared_ptr<const Config>* outConfig) const;
+    [[clang::warn_unused_result]] Error getChangedCompositionTypes(
+            std::unordered_map<Layer*, Composition>* outTypes);
+    [[clang::warn_unused_result]] Error getColorModes(
+            std::vector<android_color_mode_t>* outModes) const;
+
+    // Doesn't call into the HWC2 device, so no errors are possible
+    std::vector<std::shared_ptr<const Config>> getConfigs() const;
+
+    [[clang::warn_unused_result]] Error getName(std::string* outName) const;
+    [[clang::warn_unused_result]] Error getRequests(
+            DisplayRequest* outDisplayRequests,
+            std::unordered_map<Layer*, LayerRequest>* outLayerRequests);
+    [[clang::warn_unused_result]] Error getType(DisplayType* outType) const;
+    [[clang::warn_unused_result]] Error supportsDoze(bool* outSupport) const;
+    [[clang::warn_unused_result]] Error getHdrCapabilities(
+            std::unique_ptr<android::HdrCapabilities>* outCapabilities) const;
+    [[clang::warn_unused_result]] Error getReleaseFences(
+            std::unordered_map<Layer*,
+                    android::sp<android::Fence>>* outFences) const;
+    [[clang::warn_unused_result]] Error present(
+            android::sp<android::Fence>* outPresentFence);
+    [[clang::warn_unused_result]] Error setActiveConfig(
+            const std::shared_ptr<const Config>& config);
+    [[clang::warn_unused_result]] Error setClientTarget(
+            uint32_t slot, const android::sp<android::GraphicBuffer>& target,
+            const android::sp<android::Fence>& acquireFence,
+            android_dataspace_t dataspace);
+    [[clang::warn_unused_result]] Error setColorMode(android_color_mode_t mode);
+    [[clang::warn_unused_result]] Error setColorTransform(
+            const android::mat4& matrix, android_color_transform_t hint);
+    [[clang::warn_unused_result]] Error setOutputBuffer(
+            const android::sp<android::GraphicBuffer>& buffer,
+            const android::sp<android::Fence>& releaseFence);
+    [[clang::warn_unused_result]] Error setPowerMode(PowerMode mode);
+    [[clang::warn_unused_result]] Error setVsyncEnabled(Vsync enabled);
+    [[clang::warn_unused_result]] Error validate(uint32_t* outNumTypes,
+            uint32_t* outNumRequests);
+    [[clang::warn_unused_result]] Error presentOrValidate(uint32_t* outNumTypes,
+                                                 uint32_t* outNumRequests,
+                                                          android::sp<android::Fence>* outPresentFence, uint32_t* state);
+
+    // Most methods in this class write a command to a command buffer.  The
+    // command buffer is implicitly submitted in validate, present, and
+    // presentOrValidate.  This method provides a way to discard the commands,
+    // which can be used to discard stale commands.
+    void discardCommands();
+
+    // Other Display methods
+
+    hwc2_display_t getId() const { return mId; }
+    bool isConnected() const { return mIsConnected; }
+    void setConnected(bool connected);  // For use by Device only
+
+private:
+    int32_t getAttribute(hwc2_config_t configId, Attribute attribute);
+    void loadConfig(hwc2_config_t configId);
+    void loadConfigs();
+
+    // This may fail (and return a null pointer) if no layer with this ID exists
+    // on this display
+    Layer* getLayerById(hwc2_layer_t id) const;
+
+    // Member variables
+
+    // These are references to data owned by HWC2::Device, which will outlive
+    // this HWC2::Display, so these references are guaranteed to be valid for
+    // the lifetime of this object.
+    android::Hwc2::Composer& mComposer;
+    const std::unordered_set<Capability>& mCapabilities;
+
+    hwc2_display_t mId;
+    bool mIsConnected;
+    DisplayType mType;
+    std::unordered_map<hwc2_layer_t, std::unique_ptr<Layer>> mLayers;
+    // The ordering in this map matters, for getConfigs(), when it is
+    // converted to a vector
+    std::map<hwc2_config_t, std::shared_ptr<const Config>> mConfigs;
+};
+
+// Convenience C++ class to access hwc2_device_t Layer functions directly.
+class Layer
+{
+public:
+    Layer(android::Hwc2::Composer& composer,
+          const std::unordered_set<Capability>& capabilities,
+          hwc2_display_t displayId, hwc2_layer_t layerId);
+    ~Layer();
+
+    hwc2_layer_t getId() const { return mId; }
+
+    // Register a listener to be notified when the layer is destroyed. When the
+    // listener function is called, the Layer will be in the process of being
+    // destroyed, so it's not safe to call methods on it.
+    void setLayerDestroyedListener(std::function<void(Layer*)> listener);
+
+    [[clang::warn_unused_result]] Error setCursorPosition(int32_t x, int32_t y);
+    [[clang::warn_unused_result]] Error setBuffer(uint32_t slot,
+            const android::sp<android::GraphicBuffer>& buffer,
+            const android::sp<android::Fence>& acquireFence);
+    [[clang::warn_unused_result]] Error setSurfaceDamage(
+            const android::Region& damage);
+
+    [[clang::warn_unused_result]] Error setBlendMode(BlendMode mode);
+    [[clang::warn_unused_result]] Error setColor(hwc_color_t color);
+    [[clang::warn_unused_result]] Error setCompositionType(Composition type);
+    [[clang::warn_unused_result]] Error setDataspace(
+            android_dataspace_t dataspace);
+    [[clang::warn_unused_result]] Error setDisplayFrame(
+            const android::Rect& frame);
+    [[clang::warn_unused_result]] Error setPlaneAlpha(float alpha);
+    [[clang::warn_unused_result]] Error setSidebandStream(
+            const native_handle_t* stream);
+    [[clang::warn_unused_result]] Error setSourceCrop(
+            const android::FloatRect& crop);
+    [[clang::warn_unused_result]] Error setTransform(Transform transform);
+    [[clang::warn_unused_result]] Error setVisibleRegion(
+            const android::Region& region);
+    [[clang::warn_unused_result]] Error setZOrder(uint32_t z);
+    [[clang::warn_unused_result]] Error setInfo(uint32_t type, uint32_t appId);
+
+private:
+    // These are references to data owned by HWC2::Device, which will outlive
+    // this HWC2::Layer, so these references are guaranteed to be valid for
+    // the lifetime of this object.
+    android::Hwc2::Composer& mComposer;
+    const std::unordered_set<Capability>& mCapabilities;
+
+    hwc2_display_t mDisplayId;
+    hwc2_layer_t mId;
+    android_dataspace mDataSpace = HAL_DATASPACE_UNKNOWN;
+    std::function<void(Layer*)> mLayerDestroyedListener;
+};
+
+} // namespace HWC2
+
+#endif // ANDROID_SF_HWC2_H

--- a/compat/hwc2/hwc2_compatibility_layer.cpp
+++ b/compat/hwc2/hwc2_compatibility_layer.cpp
@@ -1,0 +1,379 @@
+/*
+ * Copyright (C) 2018 TheKit <nekit1000@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <ui/Fence.h>
+#include <ui/FloatRect.h>
+#include <ui/GraphicBuffer.h>
+#include <ui/Region.h>
+#include <sync/sync.h>
+
+#include "HWC2.h"
+#include "hwc2_compatibility_layer.h"
+
+class HWComposerCallback : public HWC2::ComposerCallback
+{
+public:
+    HWComposerCallback(HWC2EventListener* listener);
+
+    void onVsyncReceived(int32_t sequenceId, hwc2_display_t display,
+                        int64_t timestamp) override;
+    void onHotplugReceived(int32_t sequenceId, hwc2_display_t display,
+                        HWC2::Connection connection,
+                        bool primaryDisplay) override;
+    void onRefreshReceived(int32_t sequenceId,
+                           hwc2_display_t display) override;
+private:
+    HWC2EventListener *listener;
+};
+
+HWComposerCallback::HWComposerCallback(HWC2EventListener* listener) :
+    listener(listener)
+{
+}
+
+void HWComposerCallback::onVsyncReceived(int32_t sequenceId,
+                                         hwc2_display_t display,
+                                         int64_t timestamp)
+{
+    listener->on_vsync_received(listener, sequenceId, display, timestamp);
+}
+
+void HWComposerCallback::onHotplugReceived(int32_t sequenceId,
+                                           hwc2_display_t display,
+                                           HWC2::Connection connection,
+                                           bool primaryDisplay)
+{
+    listener->on_hotplug_received(listener, sequenceId, display,
+                                  connection == HWC2::Connection::Connected,
+                                  primaryDisplay);
+}
+
+void HWComposerCallback::onRefreshReceived(int32_t sequenceId,
+                                           hwc2_display_t display)
+{
+    listener->on_refresh_received(listener, sequenceId, display);
+}
+
+struct hwc2_compat_device
+{
+    HWC2::Device *self;
+};
+
+struct hwc2_compat_display
+{
+    HWC2::Display *self;
+};
+
+struct hwc2_compat_layer
+{
+    HWC2::Layer *self;
+};
+
+struct hwc2_compat_out_fences
+{
+    std::unordered_map<HWC2::Layer*, android::sp<android::Fence>> fences;
+};
+
+hwc2_compat_device_t* hwc2_compat_device_new(bool useVrComposer)
+{
+    hwc2_compat_device_t *device = (hwc2_compat_device_t*) malloc(
+        sizeof(hwc2_compat_device_t));
+    if (!device)
+        return nullptr;
+
+    device->self = new HWC2::Device(useVrComposer);
+
+    return device;
+}
+
+void hwc2_compat_device_register_callback(hwc2_compat_device_t *device,
+                                          HWC2EventListener* listener,
+                                          int composerSequenceId)
+{
+    device->self->registerCallback(new HWComposerCallback(listener),
+                                composerSequenceId);
+}
+
+void hwc2_compat_device_on_hotplug(hwc2_compat_device_t* device,
+                                    hwc2_display_t displayId, bool connected)
+{
+    device->self->onHotplug(displayId,
+                            static_cast<HWC2::Connection>(connected));
+}
+
+hwc2_compat_display_t* hwc2_compat_device_get_display_by_id(
+                            hwc2_compat_device_t *device, hwc2_display_t id)
+{
+    hwc2_compat_display_t *display = (hwc2_compat_display_t*) malloc(
+        sizeof(hwc2_compat_display_t));
+    if (!display)
+        return nullptr;
+
+    display->self = device->self->getDisplayById(id);
+
+    if (!display->self) {
+        free(display);
+        return nullptr;
+    }
+
+    return display;
+}
+
+HWC2DisplayConfig* hwc2_compat_display_get_active_config(
+                            hwc2_compat_display_t* display)
+{
+    HWC2DisplayConfig* config = (HWC2DisplayConfig*) malloc(
+        sizeof(HWC2DisplayConfig));
+
+    std::shared_ptr<const HWC2::Display::Config> activeConfig;
+    auto error = display->self->getActiveConfig(&activeConfig);
+    if (error == HWC2::Error::BadConfig) {
+        fprintf(stderr, "getActiveConfig: No config active, returning null");
+    } else if (error != HWC2::Error::None) {
+        fprintf(stderr, "getActiveConfig failed for display %d: %s (%d)",
+                static_cast<int32_t>(display->self->getId()),
+                to_string(error).c_str(),
+                static_cast<int32_t>(error));
+    } else if (!activeConfig) {
+        fprintf(stderr, "getActiveConfig returned empty config for display %d",
+                static_cast<int32_t>(display->self->getId()));
+    } else {
+        config->id = activeConfig->getId();
+        config->display = activeConfig->getDisplayId();
+        config->width = activeConfig->getWidth();
+        config->height = activeConfig->getHeight();
+        config->vsyncPeriod = activeConfig->getVsyncPeriod();
+        config->dpiX = activeConfig->getDpiX();
+        config->dpiY = activeConfig->getDpiY();
+
+        return config;
+    }
+
+    return nullptr;
+}
+
+hwc2_error_t hwc2_compat_display_accept_changes(hwc2_compat_display_t* display)
+{
+    HWC2::Error error = display->self->acceptChanges();
+    return static_cast<hwc2_error_t>(error);
+}
+
+hwc2_compat_layer_t* hwc2_compat_display_create_layer(hwc2_compat_display_t* display)
+{
+    hwc2_compat_layer_t *layer = (hwc2_compat_layer_t*) malloc(
+        sizeof(hwc2_compat_layer_t));
+    if (!layer)
+        return nullptr;
+
+    display->self->createLayer(&layer->self);
+
+    return layer;
+}
+
+void hwc2_compat_display_destroy_layer(hwc2_compat_display_t* display,
+                                       hwc2_compat_layer_t* layer)
+{
+    display->self->destroyLayer(layer->self);
+
+    delete layer->self;
+    free(layer);
+}
+
+hwc2_error_t hwc2_compat_display_get_release_fences(hwc2_compat_display_t* display,
+                                       hwc2_compat_out_fences_t** outFences)
+{
+    hwc2_compat_out_fences_t *fences = new struct hwc2_compat_out_fences;
+
+    HWC2::Error error = display->self->getReleaseFences(&fences->fences);
+    if (error != HWC2::Error::None) {
+        delete fences;
+    } else {
+        *outFences = fences;
+    }
+
+    return static_cast<hwc2_error_t>(error);
+}
+
+hwc2_error_t hwc2_compat_display_present(hwc2_compat_display_t* display,
+                                    int32_t* outPresentFence)
+{
+    android::sp<android::Fence> presentFence;
+    HWC2::Error error = display->self->present(&presentFence);
+
+    *outPresentFence = presentFence->dup();
+
+    return static_cast<hwc2_error_t>(error);
+}
+
+hwc2_error_t hwc2_compat_display_set_client_target(hwc2_compat_display_t* display,
+                                            uint32_t slot,
+                                            ANativeWindowBuffer* buffer,
+                                            const int32_t acquireFenceFd,
+                                            android_dataspace_t dataspace)
+{
+    android::sp<android::GraphicBuffer> target(
+        new android::GraphicBuffer(buffer->handle,
+            android::GraphicBuffer::WRAP_HANDLE,
+            buffer->width, buffer->height,
+            buffer->format, /* layerCount */ 1,
+            buffer->usage, buffer->stride));
+
+    android::sp<android::Fence> acquireFence(
+            new android::Fence(acquireFenceFd));
+
+    HWC2::Error error = display->self->setClientTarget(0, target,
+                                        acquireFence, HAL_DATASPACE_UNKNOWN);
+
+    return static_cast<hwc2_error_t>(error);
+}
+
+hwc2_error_t hwc2_compat_display_set_power_mode(hwc2_compat_display_t* display,
+                                        int mode)
+{
+    HWC2::Error error = display->self->setPowerMode(
+        static_cast<HWC2::PowerMode>(mode));
+    return static_cast<hwc2_error_t>(error);
+}
+
+hwc2_error_t hwc2_compat_display_set_vsync_enabled(hwc2_compat_display_t* display,
+                                           int enabled)
+{
+    HWC2::Error error = display->self->setVsyncEnabled(
+        static_cast<HWC2::Vsync>(enabled));
+    return static_cast<hwc2_error_t>(error);
+}
+
+hwc2_error_t hwc2_compat_display_validate(hwc2_compat_display_t* display,
+                                 uint32_t* outNumTypes,
+                                 uint32_t* outNumRequests)
+{
+    HWC2::Error error = display->self->validate(outNumTypes, outNumRequests);
+    return static_cast<hwc2_error_t>(error);
+}
+
+hwc2_error_t hwc2_compat_layer_set_buffer(hwc2_compat_layer_t* layer,
+                                          uint32_t slot,
+                                          ANativeWindowBuffer* buffer,
+                                          const int32_t acquireFenceFd)
+{
+    android::sp<android::GraphicBuffer> target(
+        new android::GraphicBuffer(buffer->handle,
+            android::GraphicBuffer::WRAP_HANDLE,
+            buffer->width, buffer->height,
+            buffer->format, /* layerCount */ 1,
+            buffer->usage, buffer->stride));
+
+    android::sp<android::Fence> acquireFence(
+            new android::Fence(acquireFenceFd));
+
+    HWC2::Error error = layer->self->setBuffer(0, target, acquireFence);
+
+    return static_cast<hwc2_error_t>(error);
+}
+
+hwc2_error_t hwc2_compat_layer_set_blend_mode(hwc2_compat_layer_t* layer, int mode)
+{
+    HWC2::Error error = layer->self->setBlendMode(
+        static_cast<HWC2::BlendMode>(mode));
+    return static_cast<hwc2_error_t>(error);
+}
+
+hwc2_error_t hwc2_compat_layer_set_color(hwc2_compat_layer_t* layer,
+                                    hwc_color_t color)
+{
+    HWC2::Error error = layer->self->setColor(color);
+    return static_cast<hwc2_error_t>(error);
+}
+
+hwc2_error_t hwc2_compat_layer_set_composition_type(hwc2_compat_layer_t* layer,
+                                            int type)
+{
+    HWC2::Error error = layer->self->setCompositionType(
+        static_cast<HWC2::Composition>(type));
+    return static_cast<hwc2_error_t>(error);
+}
+
+hwc2_error_t hwc2_compat_layer_set_dataspace(hwc2_compat_layer_t* layer,
+                                        android_dataspace_t dataspace)
+{
+    HWC2::Error error = layer->self->setDataspace(dataspace);
+    return static_cast<hwc2_error_t>(error);
+}
+
+hwc2_error_t hwc2_compat_layer_set_display_frame(hwc2_compat_layer_t* layer,
+                                            int32_t left, int32_t top,
+                                            int32_t right, int32_t bottom)
+{
+    android::Rect r = {left, top, right, bottom};
+
+    HWC2::Error error = layer->self->setDisplayFrame(r);
+    return static_cast<hwc2_error_t>(error);
+}
+hwc2_error_t hwc2_compat_layer_set_plane_alpha(hwc2_compat_layer_t* layer,
+                                        float alpha)
+{
+    HWC2::Error error = layer->self->setPlaneAlpha(alpha);
+    return static_cast<hwc2_error_t>(error);
+}
+hwc2_error_t hwc2_compat_layer_set_sideband_stream(hwc2_compat_layer_t* layer,
+                                            const native_handle_t* stream)
+{
+    HWC2::Error error = layer->self->setSidebandStream(stream);
+    return static_cast<hwc2_error_t>(error);
+}
+hwc2_error_t hwc2_compat_layer_set_source_crop(hwc2_compat_layer_t* layer,
+                                        float left, float top,
+                                        float right, float bottom)
+{
+    android::FloatRect r = {left, top, right, bottom};
+
+    HWC2::Error error = layer->self->setSourceCrop(r);
+    return static_cast<hwc2_error_t>(error);
+}
+hwc2_error_t hwc2_compat_layer_set_transform(hwc2_compat_layer_t* layer,
+                                        int transform)
+{
+    HWC2::Error error = layer->self->setTransform(
+        static_cast<HWC2::Transform>(transform));
+    return static_cast<hwc2_error_t>(error);
+}
+
+hwc2_error_t hwc2_compat_layer_set_visible_region(hwc2_compat_layer_t* layer,
+                                            int32_t left, int32_t top,
+                                            int32_t right, int32_t bottom)
+{
+    android::Rect r = {left, top, right, bottom};
+
+    HWC2::Error error = layer->self->setVisibleRegion(android::Region(r));
+    return static_cast<hwc2_error_t>(error);
+}
+
+int32_t hwc2_compat_out_fences_get_fence(hwc2_compat_out_fences_t* fences,
+                                         hwc2_compat_layer_t* layer)
+{
+    auto iter = fences->fences.find(layer->self);
+
+    if(iter != fences->fences.end()) {
+        return iter->second->dup();
+    } else {
+        return -1;
+    }
+}
+
+void hwc2_compat_out_fences_destroy(hwc2_compat_out_fences_t* fences)
+{
+    delete fences;
+}

--- a/compat/hwc2/hwc2_compatibility_layer.h
+++ b/compat/hwc2/hwc2_compatibility_layer.h
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2018 TheKit <nekit1000@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef HWC2_COMPATIBILITY_LAYER_H_
+#define HWC2_COMPATIBILITY_LAYER_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <unistd.h>
+
+#include <hardware/hwcomposer2.h>
+#include <system/graphics.h>
+#include <system/window.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+    struct HWC2EventListener;
+    typedef struct HWC2EventListener HWC2EventListener;
+
+    typedef void (*on_vsync_received_callback)(HWC2EventListener* listener,
+                    int32_t sequenceId, hwc2_display_t display,
+                    int64_t timestamp);
+    typedef void (*on_hotplug_received_callback)(HWC2EventListener* listener,
+                    int32_t sequenceId, hwc2_display_t display,
+                    bool connected, bool primaryDisplay);
+    typedef void (*on_refresh_received_callback)(HWC2EventListener* listener,
+                    int32_t sequenceId, hwc2_display_t display);
+
+    struct HWC2EventListener
+    {
+        on_vsync_received_callback on_vsync_received;
+        on_hotplug_received_callback on_hotplug_received;
+        on_refresh_received_callback on_refresh_received;
+    };
+
+    typedef struct HWC2DisplayConfig {
+        hwc2_config_t id;
+        hwc2_display_t display;
+        int32_t width;
+        int32_t height;
+        int64_t vsyncPeriod;
+        float dpiX;
+        float dpiY;
+    } HWC2DisplayConfig;
+
+    struct hwc2_compat_device;
+    typedef struct hwc2_compat_device hwc2_compat_device_t;
+
+    struct hwc2_compat_display;
+    typedef struct hwc2_compat_display hwc2_compat_display_t;
+
+    struct hwc2_compat_layer;
+    typedef struct hwc2_compat_layer hwc2_compat_layer_t;
+
+    struct hwc2_compat_out_fences;
+    typedef struct hwc2_compat_out_fences hwc2_compat_out_fences_t;
+
+    hwc2_compat_device_t* hwc2_compat_device_new(bool);
+    void hwc2_compat_device_register_callback(hwc2_compat_device_t* device,
+                                              HWC2EventListener* listener,
+                                              int composerSequenceId);
+
+    void hwc2_compat_device_on_hotplug(hwc2_compat_device_t* device,
+                                       hwc2_display_t displayId,
+                                       bool connected);
+
+    hwc2_compat_display_t* hwc2_compat_device_get_display_by_id(
+                                hwc2_compat_device_t* device,
+                                hwc2_display_t id);
+
+    HWC2DisplayConfig* hwc2_compat_display_get_active_config(
+                                hwc2_compat_display_t* display);
+
+    hwc2_error_t hwc2_compat_display_accept_changes(hwc2_compat_display_t* display);
+    hwc2_compat_layer_t* hwc2_compat_display_create_layer(hwc2_compat_display_t*
+                                                          display);
+    void hwc2_compat_display_destroy_layer(hwc2_compat_display_t* display,
+                                           hwc2_compat_layer_t* layer);
+
+    hwc2_error_t hwc2_compat_display_get_release_fences(
+                                        hwc2_compat_display_t* display,
+                                        hwc2_compat_out_fences_t** outFences);
+
+    hwc2_error_t hwc2_compat_display_present(hwc2_compat_display_t* display,
+                                     int32_t* outPresentFence);
+
+    hwc2_error_t hwc2_compat_display_set_client_target(hwc2_compat_display_t* display,
+                                               uint32_t slot,
+                                               ANativeWindowBuffer* buffer,
+                                               const int32_t acquireFenceFd,
+                                               android_dataspace_t dataspace);
+
+    hwc2_error_t hwc2_compat_display_set_power_mode(hwc2_compat_display_t* display,
+                                            int mode);
+    hwc2_error_t hwc2_compat_display_set_vsync_enabled(hwc2_compat_display_t* display,
+                                               int enabled);
+
+    hwc2_error_t hwc2_compat_display_validate(hwc2_compat_display_t* display,
+                                         uint32_t* outNumTypes,
+                                         uint32_t* outNumRequests);
+
+    hwc2_error_t hwc2_compat_display_present_or_validate(hwc2_compat_display_t* display,
+                                                 uint32_t* outNumTypes,
+                                                 uint32_t* outNumRequests,
+                                                 int32_t* outPresentFence,
+                                                 uint32_t* state);
+
+    hwc2_error_t hwc2_compat_layer_set_buffer(hwc2_compat_layer_t* layer,
+                                              uint32_t slot,
+                                              ANativeWindowBuffer* buffer,
+                                              const int32_t acquireFenceFd);
+    hwc2_error_t hwc2_compat_layer_set_blend_mode(hwc2_compat_layer_t* layer, int mode);
+    hwc2_error_t hwc2_compat_layer_set_color(hwc2_compat_layer_t* layer,
+                                     hwc_color_t color);
+    hwc2_error_t hwc2_compat_layer_set_composition_type(hwc2_compat_layer_t* layer,
+                                                int type);
+    hwc2_error_t hwc2_compat_layer_set_dataspace(hwc2_compat_layer_t* layer,
+                                         android_dataspace_t dataspace);
+    hwc2_error_t hwc2_compat_layer_set_display_frame(hwc2_compat_layer_t* layer,
+                                             int32_t left, int32_t top,
+                                             int32_t right, int32_t bottom);
+    hwc2_error_t hwc2_compat_layer_set_plane_alpha(hwc2_compat_layer_t* layer,
+                                           float alpha);
+    hwc2_error_t hwc2_compat_layer_set_sideband_stream(hwc2_compat_layer_t* layer,
+                                               native_handle_t* stream);
+    hwc2_error_t hwc2_compat_layer_set_source_crop(hwc2_compat_layer_t* layer,
+                                           float left, float top,
+                                           float right, float bottom);
+    hwc2_error_t hwc2_compat_layer_set_transform(hwc2_compat_layer_t* layer,
+                                         int transform);
+    hwc2_error_t hwc2_compat_layer_set_visible_region(hwc2_compat_layer_t* layer,
+                                              int32_t left, int32_t top,
+                                              int32_t right, int32_t bottom);
+
+    int32_t hwc2_compat_out_fences_get_fence(hwc2_compat_out_fences_t* fences,
+                                             hwc2_compat_layer_t* layer);
+    void hwc2_compat_out_fences_destroy(hwc2_compat_out_fences_t* fences);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // HWC2_COMPATIBILITY_LAYER_H_

--- a/compat/hwc2/tests/GrallocUsageConversion.cpp
+++ b/compat/hwc2/tests/GrallocUsageConversion.cpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <GrallocUsageConversion.h>
+
+#include <hardware/gralloc.h>
+#include <hardware/gralloc1.h>
+
+void android_convertGralloc0To1Usage(int32_t usage, uint64_t* producerUsage,
+                                     uint64_t* consumerUsage) {
+    constexpr uint64_t PRODUCER_MASK =
+        GRALLOC1_PRODUCER_USAGE_CPU_READ |
+        /* GRALLOC1_PRODUCER_USAGE_CPU_READ_OFTEN | */
+        GRALLOC1_PRODUCER_USAGE_CPU_WRITE |
+        /* GRALLOC1_PRODUCER_USAGE_CPU_WRITE_OFTEN | */
+        GRALLOC1_PRODUCER_USAGE_GPU_RENDER_TARGET | GRALLOC1_PRODUCER_USAGE_PROTECTED |
+        GRALLOC1_PRODUCER_USAGE_CAMERA | GRALLOC1_PRODUCER_USAGE_VIDEO_DECODER |
+        GRALLOC1_PRODUCER_USAGE_SENSOR_DIRECT_DATA;
+    constexpr uint64_t CONSUMER_MASK =
+        GRALLOC1_CONSUMER_USAGE_CPU_READ |
+        /* GRALLOC1_CONSUMER_USAGE_CPU_READ_OFTEN | */
+        GRALLOC1_CONSUMER_USAGE_GPU_TEXTURE | GRALLOC1_CONSUMER_USAGE_HWCOMPOSER |
+        GRALLOC1_CONSUMER_USAGE_CLIENT_TARGET | GRALLOC1_CONSUMER_USAGE_CURSOR |
+        GRALLOC1_CONSUMER_USAGE_VIDEO_ENCODER | GRALLOC1_CONSUMER_USAGE_CAMERA |
+        GRALLOC1_CONSUMER_USAGE_RENDERSCRIPT | GRALLOC1_CONSUMER_USAGE_GPU_DATA_BUFFER;
+    *producerUsage = static_cast<uint64_t>(usage) & PRODUCER_MASK;
+    *consumerUsage = static_cast<uint64_t>(usage) & CONSUMER_MASK;
+    if ((static_cast<uint32_t>(usage) & GRALLOC_USAGE_SW_READ_OFTEN) == GRALLOC_USAGE_SW_READ_OFTEN) {
+        *producerUsage |= GRALLOC1_PRODUCER_USAGE_CPU_READ_OFTEN;
+        *consumerUsage |= GRALLOC1_CONSUMER_USAGE_CPU_READ_OFTEN;
+    }
+    if ((static_cast<uint32_t>(usage) & GRALLOC_USAGE_SW_WRITE_OFTEN) ==
+        GRALLOC_USAGE_SW_WRITE_OFTEN) {
+        *producerUsage |= GRALLOC1_PRODUCER_USAGE_CPU_WRITE_OFTEN;
+    }
+}
+
+int32_t android_convertGralloc1To0Usage(uint64_t producerUsage, uint64_t consumerUsage) {
+    static_assert(uint64_t(GRALLOC1_CONSUMER_USAGE_CPU_READ_OFTEN) ==
+                      uint64_t(GRALLOC1_PRODUCER_USAGE_CPU_READ_OFTEN),
+                  "expected ConsumerUsage and ProducerUsage CPU_READ_OFTEN bits to match");
+    uint64_t merged = producerUsage | consumerUsage;
+    if ((merged & (GRALLOC1_CONSUMER_USAGE_CPU_READ_OFTEN)) ==
+        GRALLOC1_CONSUMER_USAGE_CPU_READ_OFTEN) {
+        merged &= ~uint64_t(GRALLOC1_CONSUMER_USAGE_CPU_READ_OFTEN);
+        merged |= GRALLOC_USAGE_SW_READ_OFTEN;
+    }
+    if ((merged & (GRALLOC1_PRODUCER_USAGE_CPU_WRITE_OFTEN)) ==
+        GRALLOC1_PRODUCER_USAGE_CPU_WRITE_OFTEN) {
+        merged &= ~uint64_t(GRALLOC1_PRODUCER_USAGE_CPU_WRITE_OFTEN);
+        merged |= GRALLOC_USAGE_SW_WRITE_OFTEN;
+    }
+    return static_cast<int32_t>(merged);
+}

--- a/compat/hwc2/tests/GrallocUsageConversion.h
+++ b/compat/hwc2/tests/GrallocUsageConversion.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ANDROID_GRALLOCUSAGE_GRALLOC_USAGE_CONVERSION_H
+#define ANDROID_GRALLOCUSAGE_GRALLOC_USAGE_CONVERSION_H 1
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Conversion functions are out-of-line so that users don't have to be exposed to
+// android/hardware/graphics/allocator/2.0/types.h and link against
+// android.hardware.graphics.allocator@2.0 to get that in their search path.
+
+// Convert a 32-bit gralloc0 usage mask to a producer/consumer pair of 64-bit usage masks as used
+// by android.hardware.graphics.allocator@2.0 (and gralloc1). This conversion properly handles the
+// mismatch between a.h.g.allocator@2.0's CPU_{READ,WRITE}_OFTEN and gralloc0's
+// SW_{READ,WRITE}_OFTEN.
+void android_convertGralloc0To1Usage(int32_t usage, uint64_t* producerUsage,
+                                     uint64_t* consumerUsage);
+
+// Convert a producer/consumer pair of 64-bit usage masks as used by
+// android.hardware.graphics.allocator@2.0 (and gralloc1) to a 32-bit gralloc0 usage mask. This
+// conversion properly handles the mismatch between a.h.g.allocator@2.0's CPU_{READ,WRITE}_OFTEN
+// and gralloc0's SW_{READ,WRITE}_OFTEN.
+int32_t android_convertGralloc1To0Usage(uint64_t producerUsage, uint64_t consumerUsage);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // ANDROID_GRALLOCUSAGE_GRALLOC_USAGE_CONVERSION_H

--- a/compat/hwc2/tests/direct_hwc2_test.cpp
+++ b/compat/hwc2/tests/direct_hwc2_test.cpp
@@ -1,0 +1,353 @@
+/*
+ * Copyright (C) 2018 TheKit <nekit1000@gmail.com>
+ * Copyright (c) 2012 Carsten Munk <carsten.munk@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <math.h>
+#include <mutex>
+
+#include <EGL/egl.h>
+#include <GLES2/gl2.h>
+#include <cutils/log.h>
+#include <sync/sync.h>
+
+#include "hybris-gralloc.h"
+#include <hwcomposer_window.h>
+
+#include "hwc2_compatibility_layer.h"
+
+const char vertex_src [] =
+"                                        \
+   attribute vec4        position;       \
+   varying mediump vec2  pos;            \
+   uniform vec4          offset;         \
+                                         \
+   void main()                           \
+   {                                     \
+      gl_Position = position + offset;   \
+      pos = position.xy;                 \
+   }                                     \
+";
+
+
+const char fragment_src [] =
+"                                                      \
+   varying mediump vec2    pos;                        \
+   uniform mediump float   phase;                      \
+                                                       \
+   void  main()                                        \
+   {                                                   \
+      gl_FragColor  =  vec4( 1., 0.9, 0.7, 1.0 ) *     \
+        cos( 30.*sqrt(pos.x*pos.x + 1.5*pos.y*pos.y)   \
+             + atan(pos.y,pos.x) - phase );            \
+   }                                                   \
+";
+
+GLuint load_shader(const char *shader_source, GLenum type)
+{
+    GLuint  shader = glCreateShader(type);
+
+    glShaderSource(shader, 1, &shader_source, NULL);
+    glCompileShader(shader);
+
+    return shader;
+}
+
+
+GLfloat norm_x    =  0.0;
+GLfloat norm_y    =  0.0;
+GLfloat offset_x  =  0.0;
+GLfloat offset_y  =  0.0;
+GLfloat p1_pos_x  =  0.0;
+GLfloat p1_pos_y  =  0.0;
+
+GLint phase_loc;
+GLint offset_loc;
+GLint position_loc;
+
+const float vertexArray[] = {
+    0.0,  1.0,  0.0,
+    -1.,  0.0,  0.0,
+    0.0, -1.0,  0.0,
+    1.,  0.0,  0.0,
+    0.0,  1.,  0.0
+};
+
+std::mutex hotplugMutex;
+std::condition_variable hotplugCv;
+hwc2_compat_device_t* hwcDevice;
+
+class HWComposer : public HWComposerNativeWindow
+{
+    private:
+        hwc2_compat_layer_t *layer;
+        hwc2_compat_display_t *hwcDisplay;
+        int lastPresentFence = -1;
+    protected:
+        void present(HWComposerNativeWindowBuffer *buffer);
+
+    public:
+
+        HWComposer(unsigned int width, unsigned int height, unsigned int format,
+                hwc2_compat_display_t *display, hwc2_compat_layer_t *layer);
+        void set();
+};
+
+HWComposer::HWComposer(unsigned int width, unsigned int height,
+                    unsigned int format, hwc2_compat_display_t* display,
+                    hwc2_compat_layer_t *layer) :
+                    HWComposerNativeWindow(width, height, format)
+{
+    this->layer = layer;
+    this->hwcDisplay = display;
+}
+
+void HWComposer::present(HWComposerNativeWindowBuffer *buffer)
+{
+    uint32_t numTypes = 0;
+    uint32_t numRequests = 0;
+    hwc2_display_t displayId = 0;
+
+    hwc2_error_t error = hwc2_compat_display_validate(hwcDisplay, &numTypes,
+                                                      &numRequests);
+
+    if (error != HWC2_ERROR_NONE && error != HWC2_ERROR_HAS_CHANGES) {
+        ALOGE("prepare: validate failed for display %d: %s (%d)",
+              (uint32_t) displayId,
+              to_string(static_cast<HWC2::Error>(error)).c_str(), error);
+        return;
+    }
+
+    if (numTypes || numRequests) {
+        ALOGE("prepare: validate required changes for display %d: %s (%d)",
+              (uint32_t) displayId,
+              to_string(static_cast<HWC2::Error>(error)).c_str(), error);
+        return;
+    }
+
+    error = hwc2_compat_display_accept_changes(hwcDisplay);
+    if (error != HWC2_ERROR_NONE) {
+        ALOGE("prepare: acceptChanges failed: %s",
+              to_string(static_cast<HWC2::Error>(error)).c_str());
+        return;
+    }
+
+    hwc2_compat_display_set_client_target(hwcDisplay, /* slot */0, buffer,
+                                          getFenceBufferFd(buffer),
+                                          HAL_DATASPACE_UNKNOWN);
+
+    int presentFence;
+    hwc2_compat_display_present(hwcDisplay, &presentFence);
+
+    if (error != HWC2_ERROR_NONE) {
+        ALOGE("presentAndGetReleaseFences: failed for display %d: %s (%d)",
+              (uint32_t) displayId,
+              to_string(static_cast<HWC2::Error>(error)).c_str(), error);
+        return;
+    }
+
+    hwc2_compat_out_fences_t* fences;
+    error = hwc2_compat_display_get_release_fences(
+        hwcDisplay, &fences);
+
+    if (error != HWC2_ERROR_NONE) {
+        ALOGE("presentAndGetReleaseFences: Failed to get release fences "
+              "for display %d: %s (%d)",
+              (uint32_t) displayId, to_string(static_cast<HWC2::Error>(error)).c_str(),
+              error);
+        return;
+    }
+
+    int fenceFd = hwc2_compat_out_fences_get_fence(fences, layer);
+    if (fenceFd != -1)
+        setFenceBufferFd(buffer, fenceFd);
+
+    hwc2_compat_out_fences_destroy(fences);
+
+    if (lastPresentFence != -1) {
+        sync_wait(lastPresentFence, -1);
+        close(lastPresentFence);
+    }
+    lastPresentFence = presentFence;
+}
+
+void onVsyncReceived(HWC2EventListener* listener, int32_t sequenceId,
+                     hwc2_display_t display, int64_t timestamp)
+{
+}
+
+void onHotplugReceived(HWC2EventListener* listener, int32_t sequenceId,
+                       hwc2_display_t display, bool connected,
+                       bool primaryDisplay)
+{
+    ALOGI("onHotplugReceived(%d, %" PRIu64 ", %s, %s)",
+        sequenceId, display,
+        connected ?
+                "connected" : "disconnected",
+        primaryDisplay ? "primary" : "external");
+
+    {
+        std::lock_guard<std::mutex> lock(hotplugMutex);
+        hwc2_compat_device_on_hotplug(hwcDevice, display, connected);
+    }
+
+    hotplugCv.notify_all();
+}
+
+void onRefreshReceived(HWC2EventListener* listener,
+                       int32_t sequenceId, hwc2_display_t display)
+{
+}
+
+HWC2EventListener eventListener = {
+    &onVsyncReceived,
+    &onHotplugReceived,
+    &onRefreshReceived
+};
+
+int main()
+{
+    EGLDisplay display;
+    EGLConfig ecfg;
+    EGLint num_config;
+    EGLint attr[] = {       // some attributes to set up our egl-interface
+        EGL_BUFFER_SIZE, 32,
+        EGL_RENDERABLE_TYPE,
+        EGL_OPENGL_ES2_BIT,
+        EGL_NONE
+    };
+    EGLSurface surface;
+    EGLint ctxattr[] = {
+        EGL_CONTEXT_CLIENT_VERSION, 2,
+        EGL_NONE
+    };
+    EGLContext context;
+
+    EGLBoolean rv;
+
+    int err;
+    int composerSequenceId = 0;
+
+    hwcDevice = hwc2_compat_device_new(false);
+    assert(hwcDevice);
+
+    hwc2_compat_device_register_callback(hwcDevice, &eventListener,
+                                         composerSequenceId);
+
+    std::unique_lock<std::mutex> lock(hotplugMutex);
+    hwc2_compat_display_t* hwcDisplay;
+    while (!(hwcDisplay = hwc2_compat_device_get_display_by_id(hwcDevice, 0))) {
+        /* Wait at most 5s for hotplug events */
+        hotplugCv.wait_for(lock, std::chrono::seconds(5));
+    }
+    hotplugMutex.unlock();
+    assert(hwcDisplay);
+
+    hwc2_compat_display_set_power_mode(hwcDisplay, HWC2_POWER_MODE_ON);
+
+    std::shared_ptr<HWC2DisplayConfig> config = {
+        hwc2_compat_display_get_active_config(hwcDisplay), free };
+
+    printf("width: %i height: %i\n", config->width, config->height);
+
+    hwc2_compat_layer_t* layer = hwc2_compat_display_create_layer(hwcDisplay);
+
+    hwc2_compat_layer_set_composition_type(layer, HWC2_COMPOSITION_CLIENT);
+    hwc2_compat_layer_set_blend_mode(layer, HWC2_BLEND_MODE_NONE);
+    hwc2_compat_layer_set_source_crop(layer, 0.0f, 0.0f, config->width,
+                                      config->height);
+    hwc2_compat_layer_set_display_frame(layer, 0, 0, config->width,
+                                        config->height);
+    hwc2_compat_layer_set_visible_region(layer, 0, 0, config->width,
+                                         config->height);
+
+    HWComposer *win = new HWComposer(config->width, config->height,
+                                     HAL_PIXEL_FORMAT_RGBA_8888, hwcDisplay,
+                                     layer);
+    printf("created native window\n");
+    hybris_gralloc_initialize(0);
+
+    display = eglGetDisplay(EGL_DEFAULT_DISPLAY);
+    assert(eglGetError() == EGL_SUCCESS);
+    assert(display != EGL_NO_DISPLAY);
+
+    rv = eglInitialize(display, 0, 0);
+    assert(eglGetError() == EGL_SUCCESS);
+    assert(rv == EGL_TRUE);
+
+    eglChooseConfig((EGLDisplay) display, attr, &ecfg, 1, &num_config);
+    assert(eglGetError() == EGL_SUCCESS);
+    assert(rv == EGL_TRUE);
+
+    surface = eglCreateWindowSurface((EGLDisplay) display, ecfg,
+        (EGLNativeWindowType) static_cast<ANativeWindow *> (win), NULL);
+    assert(eglGetError() == EGL_SUCCESS);
+    assert(surface != EGL_NO_SURFACE);
+
+    context = eglCreateContext((EGLDisplay) display, ecfg, EGL_NO_CONTEXT,
+                               ctxattr);
+    assert(eglGetError() == EGL_SUCCESS);
+    assert(context != EGL_NO_CONTEXT);
+
+    assert(eglMakeCurrent((EGLDisplay) display, surface, surface,
+                          context) == EGL_TRUE);
+
+    const char *version = (const char *)glGetString(GL_VERSION);
+    assert(version);
+    printf("%s\n",version);
+
+    GLuint vertexShader = load_shader (vertex_src, GL_VERTEX_SHADER);
+    GLuint fragmentShader = load_shader(fragment_src, GL_FRAGMENT_SHADER);
+
+    GLuint shaderProgram = glCreateProgram();
+    glAttachShader(shaderProgram, vertexShader);
+    glAttachShader(shaderProgram, fragmentShader);
+
+    glLinkProgram(shaderProgram);
+    glUseProgram(shaderProgram);
+
+    position_loc = glGetAttribLocation(shaderProgram, "position");
+    phase_loc = glGetUniformLocation(shaderProgram, "phase");
+    offset_loc = glGetUniformLocation(shaderProgram, "offset");
+
+    if (position_loc < 0 ||  phase_loc < 0 || offset_loc < 0) {
+        return 1;
+    }
+
+    glClearColor (1., 1., 1., 1.); // background color
+    float phase = 0;
+    int i, oldretire = -1, oldrelease = -1, oldrelease2 = -1;
+    for (i=0; i<60*60; ++i) {
+        glClear(GL_COLOR_BUFFER_BIT);
+        glUniform1f (phase_loc, phase);
+        phase = fmodf (phase + 0.5f, 2.f * 3.141f);
+
+        glUniform4f(offset_loc, offset_x, offset_y, 0.0, 0.0);
+
+        glVertexAttribPointer(position_loc, 3, GL_FLOAT,
+                              GL_FALSE, 0, vertexArray);
+        glEnableVertexAttribArray (position_loc);
+        glDrawArrays (GL_TRIANGLE_STRIP, 0, 5);
+
+        eglSwapBuffers ((EGLDisplay) display, surface);
+    }
+
+    printf("stop\n");
+
+    return 0;
+}

--- a/compat/hwc2/tests/hwcomposer.h
+++ b/compat/hwc2/tests/hwcomposer.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2015 Jolla Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef HYBRIS_HWCOMPOSER_H
+#define HYBRIS_HWCOMPOSER_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct ANativeWindow;
+struct ANativeWindowBuffer;
+
+typedef void (*HWCPresentCallback)(void *user_data, struct ANativeWindow *window,
+                                   struct ANativeWindowBuffer *buffer);
+
+/** Create a new HWC ANativeWindow.
+ *
+ * The Window can be casted to EGLNativeWindowType and used to create
+ * an EGLSurface.
+ * The specified present callback will be called by the window when a new
+ * buffer is ready to be presented on screen. It is responsibility of the
+ * caller to make sure that happens, by using the hwcomposer API.
+ * Returns the window on success or NULL on failure.
+ *
+ * \param width The width of the window in pixels.
+ * \param height The height of the window in pixels.
+ * \param format The HAL format of the window.
+ * \param present The present callback the window will use.
+ * \param cbData The callback data the window will pass along to the present callback.
+ *
+ * \sa HWCNativeWindowDestroy
+ */
+struct ANativeWindow *HWCNativeWindowCreate(unsigned int width, unsigned int height, unsigned int format,
+                                            HWCPresentCallback present, void *cbData);
+
+/** Destroy a HWC ANativeWindow.
+ *
+ * Destroys a native window created with HWCNativeWindowCreate().
+ * It is not necessary to call this after using eglDestroyWindowSurface()
+ * with an EGLSurface backing a valid ANativeWindow, the window will
+ * be destroyed automatically.
+ *
+ * \sa HWCNativeWindowCreate
+ */
+void HWCNativeWindowDestroy(struct ANativeWindow *window);
+
+/** Get the current fence FD on a buffer.
+ *
+ * The buffer must be a buffer passed from the HWC layer trough the present
+ * callback of a ANativeWindow.
+ *
+ * \sa HWCNativeWindowCreate
+ * \sa HWCNativeBufferSetFence
+ */
+int HWCNativeBufferGetFence(struct ANativeWindowBuffer *buf);
+
+/** Set the current fence FD on a buffer.
+ *
+ * The buffer must be a buffer passed from the HWC layer trough the present
+ * callback of a ANativeWindow.
+ *
+ * \sa HWCNativeWindowCreate
+ * \sa HWCNativeBufferGetFence
+ */
+void HWCNativeBufferSetFence(struct ANativeWindowBuffer *buf, int fd);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/compat/hwc2/tests/hwcomposer_window.cpp
+++ b/compat/hwc2/tests/hwcomposer_window.cpp
@@ -1,0 +1,521 @@
+/*
+ * Copyright (C) 2013 libhybris
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "hwcomposer_window.h"
+#include "hwcomposer.h"
+
+#include <errno.h>
+#include <assert.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <stdlib.h>
+
+extern "C" {
+#include <sync/sync.h>
+};
+
+#include <android/log.h>
+//#define TRACE(fmt, ...) __android_log_print(ANDROID_LOG_DEBUG, "HWCNativeWindow", fmt "\n--> %s\n----> %s:%d", ##__VA_ARGS__, __FILE__, __FUNCTION__, __LINE__)
+#define TRACE(fmt, ...)
+
+#include "hybris-gralloc.h"
+
+extern "C" struct ANativeWindow *HWCNativeWindowCreate(unsigned int width, unsigned int height, unsigned int format, HWCPresentCallback present, void *cb_data)
+{
+    class Window : public HWComposerNativeWindow
+    {
+    public:
+        Window(unsigned int w, unsigned int h, unsigned int f, HWCPresentCallback p, void *d)
+            : HWComposerNativeWindow(w, h, f)
+            , cb(p)
+            , cb_data(d)
+        {
+        }
+
+        void present(HWComposerNativeWindowBuffer *b)
+        {
+            cb(cb_data, static_cast<ANativeWindow *>(this), static_cast<ANativeWindowBuffer *>(b));
+        }
+
+        HWCPresentCallback cb;
+        void *cb_data;
+    };
+
+    if (!present)
+        return 0;
+
+    Window *w = new Window(width, height, format, present, cb_data);
+    return w;
+}
+
+extern "C" void HWCNativeWindowDestroy(struct ANativeWindow *window)
+{
+    delete window;
+}
+
+struct _BufferFenceAccessor : public HWComposerNativeWindowBuffer {
+    int get() { return fenceFd; }
+    void set(int fd) { fenceFd = fd; };
+};
+
+extern "C" int HWCNativeBufferGetFence(struct ANativeWindowBuffer *buf)
+{
+    return static_cast<_BufferFenceAccessor *>(buf)->get();
+}
+
+extern "C" void HWCNativeBufferSetFence(struct ANativeWindowBuffer *buf, int fd)
+{
+    static_cast<_BufferFenceAccessor *>(buf)->set(fd);
+}
+
+static pthread_cond_t _cond = PTHREAD_COND_INITIALIZER;
+static pthread_mutex_t _mutex = PTHREAD_MUTEX_INITIALIZER;
+
+
+HWComposerNativeWindowBuffer::HWComposerNativeWindowBuffer(unsigned int width,
+                            unsigned int height,
+                            unsigned int format,
+                            unsigned int usage)
+{
+    ANativeWindowBuffer::width  = width;
+    ANativeWindowBuffer::height = height;
+    ANativeWindowBuffer::format = format;
+    ANativeWindowBuffer::usage  = usage;
+    fenceFd = -1;
+    busy = 0;
+    status = 0;
+
+    hybris_gralloc_allocate(width, height, format, usage, &handle, (uint32_t*)&stride);
+
+    TRACE("width=%d height=%d stride=%d format=x%x usage=x%x status=%s this=%p",
+        width, height, stride, format, usage, strerror(-status), this);
+}
+
+
+
+HWComposerNativeWindowBuffer::~HWComposerNativeWindowBuffer()
+{
+    TRACE("%p", this);
+    hybris_gralloc_release(handle, 1);
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+HWComposerNativeWindow::HWComposerNativeWindow(unsigned int width, unsigned int height, unsigned int format)
+{
+    pthread_mutex_init(&m_mutex, 0);
+    m_width = width;
+    m_height = height;
+    m_bufFormat = format;
+    m_usage = GRALLOC_USAGE_HW_COMPOSER|GRALLOC_USAGE_HW_FB;
+    m_bufferCount = 2;
+    m_nextBuffer = 0;
+}
+
+HWComposerNativeWindow::~HWComposerNativeWindow()
+{
+    destroyBuffers();
+}
+
+
+
+void HWComposerNativeWindow::destroyBuffers()
+{
+    TRACE("");
+
+    std::vector<HWComposerNativeWindowBuffer*>::iterator it = m_bufList.begin();
+    for (; it!=m_bufList.end(); ++it)
+    {
+        HWComposerNativeWindowBuffer* fbnb = *it;
+        fbnb->common.decRef(&fbnb->common);
+    }
+    m_bufList.clear();
+    m_nextBuffer = 0;
+}
+
+
+
+
+/*
+ * Set the swap interval for this surface.
+ *
+ * Returns 0 on success or -errno on error.
+ */
+int HWComposerNativeWindow::setSwapInterval(int interval)
+{
+    TRACE("interval=%i WARN STUB", interval);
+    return 0;
+}
+
+
+/*
+ * Hook called by EGL to acquire a buffer. This call may block if no
+ * buffers are available.
+ *
+ * The window holds a reference to the buffer between dequeueBuffer and
+ * either queueBuffer or cancelBuffer, so clients only need their own
+ * reference if they might use the buffer after queueing or canceling it.
+ * Holding a reference to a buffer after queueing or canceling it is only
+ * allowed if a specific buffer count has been set.
+ *
+ * The libsync fence file descriptor returned in the int pointed to by the
+ * fenceFd argument will refer to the fence that must signal before the
+ * dequeued buffer may be written to.  A value of -1 indicates that the
+ * caller may access the buffer immediately without waiting on a fence.  If
+ * a valid file descriptor is returned (i.e. any value except -1) then the
+ * caller is responsible for closing the file descriptor.
+ *
+ * Returns 0 on success or -errno on error.
+ */
+int HWComposerNativeWindow::dequeueBuffer(BaseNativeWindowBuffer** buffer, int *fenceFd)
+{
+    //HYBRIS_TRACE_BEGIN("hwcomposer-platform", "dequeueBuffer", "");
+
+    pthread_mutex_lock(&m_mutex);
+
+    // Allocate buffers if the list is empty, typically on the first call
+    if (m_bufList.empty())
+        allocateBuffers();
+    assert(!m_bufList.empty());
+    assert(m_nextBuffer < m_bufList.size());
+
+
+    // Grabe the next available buffer in the list and assign m_nextBuffer to
+    // the next one.
+    HWComposerNativeWindowBuffer *b = m_bufList.at(m_nextBuffer);
+    TRACE("idx=%d, buffer=%p, fence=%d", m_nextBuffer, b, b->fenceFd);
+    *buffer = b;
+    m_nextBuffer++;
+    if (m_nextBuffer >= m_bufList.size())
+        m_nextBuffer = 0;
+
+    // assign the buffer's fence to fenceFd and close/reset our fd.
+    int fence = b->fenceFd;
+    if (fenceFd)
+        *fenceFd = dup(fence);
+    if (fence != -1) {
+        close(b->fenceFd);
+        b->fenceFd = -1;
+    }
+
+    pthread_mutex_unlock(&m_mutex);
+    //HYBRIS_TRACE_END("hwcomposer-platform", "dequeueBuffer", "");
+    return 0;
+}
+
+/*
+ * Hook called by EGL when modifications to the render buffer are done.
+ * This unlocks and post the buffer.
+ *
+ * The window holds a reference to the buffer between dequeueBuffer and
+ * either queueBuffer or cancelBuffer, so clients only need their own
+ * reference if they might use the buffer after queueing or canceling it.
+ * Holding a reference to a buffer after queueing or canceling it is only
+ * allowed if a specific buffer count has been set.
+ *
+ * The fenceFd argument specifies a libsync fence file descriptor for a
+ * fence that must signal before the buffer can be accessed.  If the buffer
+ * can be accessed immediately then a value of -1 should be used.  The
+ * caller must not use the file descriptor after it is passed to
+ * queueBuffer, and the ANativeWindow implementation is responsible for
+ * closing it.
+ *
+ * Returns 0 on success or -errno on error.
+ */
+int HWComposerNativeWindow::queueBuffer(BaseNativeWindowBuffer* buffer, int fenceFd)
+{
+    HWComposerNativeWindowBuffer* b = (HWComposerNativeWindowBuffer*) buffer;
+    //HYBRIS_TRACE_BEGIN("hwcomposer-platform", "queueBuffer", "-%p", b);
+    TRACE("%lu %p %d", pthread_self(), buffer, fenceFd);
+
+    pthread_mutex_lock(&m_mutex);
+    assert(b->fenceFd == -1); // We reset it in dequeue, so it better be -1 still..
+    b->fenceFd = fenceFd;
+    this->present(b);
+    pthread_mutex_unlock(&m_mutex);
+
+    TRACE("%lu %p %d", pthread_self(), b, b->fenceFd);
+    //HYBRIS_TRACE_END("hwcomposer-platform", "queueBuffer", "-%p", b);
+
+    return 0;
+}
+
+int HWComposerNativeWindow::getFenceBufferFd(HWComposerNativeWindowBuffer *buffer)
+{
+    return buffer->fenceFd;
+}
+
+void HWComposerNativeWindow::setFenceBufferFd(HWComposerNativeWindowBuffer *buffer, int fd)
+{
+    buffer->fenceFd = fd;
+}
+
+/*
+ * Hook used to cancel a buffer that has been dequeued.
+ * No synchronization is performed between dequeue() and cancel(), so
+ * either external synchronization is needed, or these functions must be
+ * called from the same thread.
+ *
+ * The window holds a reference to the buffer between dequeueBuffer and
+ * either queueBuffer or cancelBuffer, so clients only need their own
+ * reference if they might use the buffer after queueing or canceling it.
+ * Holding a reference to a buffer after queueing or canceling it is only
+ * allowed if a specific buffer count has been set.
+ *
+ * The fenceFd argument specifies a libsync fence file decsriptor for a
+ * fence that must signal before the buffer can be accessed.  If the buffer
+ * can be accessed immediately then a value of -1 should be used.
+ *
+ * Note that if the client has not waited on the fence that was returned
+ * from dequeueBuffer, that same fence should be passed to cancelBuffer to
+ * ensure that future uses of the buffer are preceded by a wait on that
+ * fence.  The caller must not use the file descriptor after it is passed
+ * to cancelBuffer, and the ANativeWindow implementation is responsible for
+ * closing it.
+ *
+ * Returns 0 on success or -errno on error.
+ */
+int HWComposerNativeWindow::cancelBuffer(BaseNativeWindowBuffer* buffer, int fenceFd)
+{
+    TRACE("");
+    HWComposerNativeWindowBuffer* fbnb = (HWComposerNativeWindowBuffer*)buffer;
+
+    pthread_mutex_lock(&m_mutex);
+
+    // Assign the fence so we can pass it on in dequeue when the buffer is
+    // again acquired.
+    fbnb->fenceFd = fenceFd;
+
+    pthread_mutex_unlock(&m_mutex);
+    return 0;
+}
+
+
+
+int HWComposerNativeWindow::lockBuffer(BaseNativeWindowBuffer* buffer)
+{
+    TRACE("%lu STUB", pthread_self());
+    return NO_ERROR;
+}
+
+
+/*
+ * see NATIVE_WINDOW_FORMAT
+ */
+unsigned int HWComposerNativeWindow::width() const
+{
+    unsigned int rv = m_width;
+    TRACE("width=%i", rv);
+    return rv;
+}
+
+
+/*
+ * see NATIVE_WINDOW_HEIGHT
+ */
+unsigned int HWComposerNativeWindow::height() const
+{
+    unsigned int rv = m_height;
+    TRACE("height=%i", rv);
+    return rv;
+}
+
+
+/*
+ * see NATIVE_WINDOW_FORMAT
+ */
+unsigned int HWComposerNativeWindow::format() const
+{
+    unsigned int rv = m_bufFormat;
+    TRACE("format=x%x", rv);
+    return rv;
+}
+
+
+/*
+ * Default width and height of ANativeWindow buffers, these are the
+ * dimensions of the window buffers irrespective of the
+ * NATIVE_WINDOW_SET_BUFFERS_DIMENSIONS call and match the native window
+ * size unless overridden by NATIVE_WINDOW_SET_BUFFERS_USER_DIMENSIONS.
+ */
+/*
+ * see NATIVE_WINDOW_DEFAULT_HEIGHT
+ */
+unsigned int HWComposerNativeWindow::defaultHeight() const
+{
+    unsigned int rv = m_height;
+    TRACE("height=%i", rv);
+    return rv;
+}
+
+
+/*
+ * see BaseNativeWindow::_query(NATIVE_WINDOW_DEFAULT_WIDTH)
+ */
+unsigned int HWComposerNativeWindow::defaultWidth() const
+{
+    unsigned int rv = m_width;
+    TRACE("width=%i", rv);
+    return rv;
+}
+
+
+/*
+ * see NATIVE_WINDOW_QUEUES_TO_WINDOW_COMPOSER
+ */
+unsigned int HWComposerNativeWindow::queueLength() const
+{
+    TRACE("");
+    return 0;
+}
+
+
+/*
+ * see NATIVE_WINDOW_CONCRETE_TYPE
+ */
+unsigned int HWComposerNativeWindow::type() const
+{
+    TRACE("");
+    return NATIVE_WINDOW_FRAMEBUFFER;
+}
+
+
+/*
+ * see NATIVE_WINDOW_TRANSFORM_HINT
+ */
+unsigned int HWComposerNativeWindow::transformHint() const
+{
+    TRACE("");
+    char* transform_rot = getenv("HYBRIS_HAL_TRANSFORM_ROT");
+    if (transform_rot)
+        return atoi(transform_rot);
+    else
+        return 0;
+}
+
+/*
+ * returns the current usage of this window
+ */
+unsigned int HWComposerNativeWindow::getUsage() const
+{
+    return m_usage;
+}
+
+/*
+ *  native_window_set_usage(..., usage)
+ *  Sets the intended usage flags for the next buffers
+ *  acquired with (*lockBuffer)() and on.
+ *  By default (if this function is never called), a usage of
+ *      GRALLOC_USAGE_HW_RENDER | GRALLOC_USAGE_HW_TEXTURE
+ *  is assumed.
+ *  Calling this function will usually cause following buffers to be
+ *  reallocated.
+ */
+int HWComposerNativeWindow::setUsage(int usage)
+{
+    usage |= GRALLOC_USAGE_HW_COMPOSER|GRALLOC_USAGE_HW_FB;
+    int need_realloc = (m_usage != (unsigned int) usage);
+    TRACE("usage=x%x realloc=%d", usage, need_realloc);
+    m_usage = usage;
+    if (need_realloc)
+        destroyBuffers();
+    return NO_ERROR;
+}
+
+
+/*
+ * native_window_set_buffers_format(..., int format)
+ * All buffers dequeued after this call will have the format specified.
+ *
+ * If the specified format is 0, the default buffer format will be used.
+ */
+int HWComposerNativeWindow::setBuffersFormat(int format)
+{
+    int need_realloc = ((unsigned int) format != m_bufFormat);
+    TRACE("format=x%x realloc=%d", format, need_realloc);
+    m_bufFormat = format;
+    if (need_realloc)
+        destroyBuffers();
+
+    return NO_ERROR;
+}
+
+
+/*
+ * native_window_set_buffer_count(..., count)
+ * Sets the number of buffers associated with this native window.
+ */
+int HWComposerNativeWindow::setBufferCount(int count)
+{
+    TRACE("cnt=%d", count);
+    if ((unsigned int) count != m_bufferCount)
+        destroyBuffers();
+    m_bufferCount = count;
+    return NO_ERROR;
+}
+
+void HWComposerNativeWindow::allocateBuffers()
+{
+    // This function gets called from dequeue which already locked
+    // m_mutex, so we do this without locking here.
+    TRACE("cnt=%d", m_bufferCount);
+
+    for(unsigned int i = 0; i < m_bufferCount; i++)
+    {
+        HWComposerNativeWindowBuffer *b
+         = new HWComposerNativeWindowBuffer(m_width, m_height, m_bufFormat, m_usage);
+
+        b->common.incRef(&b->common);
+
+        TRACE("buffer %i is at %p (native %p),err=%s, handle=%p stride=%i",
+                i, b, (ANativeWindowBuffer*)b,
+                strerror(-b->status), b->handle, b->stride);
+
+        if (b->status) {
+            b->common.decRef(&b->common);
+            fprintf(stderr,"WARNING: %s: allocated only %d buffers out of %d\n", __PRETTY_FUNCTION__,
+                    (uint32_t) m_bufList.size(), m_bufferCount);
+            break;
+        }
+
+        m_bufList.push_back(b);
+    }
+
+    // Restart the count, to avoid out-of-bounds access if it shrinked.
+    m_nextBuffer = 0;
+}
+
+/*
+ * native_window_set_buffers_dimensions(..., int w, int h)
+ * All buffers dequeued after this call will have the dimensions specified.
+ * In particular, all buffers will have a fixed-size, independent from the
+ * native-window size. They will be scaled according to the scaling mode
+ * (see native_window_set_scaling_mode) upon window composition.
+ *
+ * If w and h are 0, the normal behavior is restored. That is, dequeued buffers
+ * following this call will be sized to match the window's size.
+ *
+ * Calling this function will reset the window crop to a NULL value, which
+ * disables cropping of the buffers.
+ */
+int HWComposerNativeWindow::setBuffersDimensions(int width, int height)
+{
+    TRACE("WARN: stub. size=%ix%i", width, height);
+    return NO_ERROR;
+}
+// vim: noai:ts=4:sw=4:ss=4:expandtab

--- a/compat/hwc2/tests/hwcomposer_window.h
+++ b/compat/hwc2/tests/hwcomposer_window.h
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2013 libhybris
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FBDEV_WINDOW_H
+#define FBDEV_WINDOW_H
+
+#include "nativewindowbase.h"
+#include <linux/fb.h>
+#include <hardware/gralloc.h>
+#include <pthread.h>
+
+#include <vector>
+
+
+class HWComposerNativeWindowBuffer : public BaseNativeWindowBuffer {
+friend class HWComposerNativeWindow;
+
+protected:
+    HWComposerNativeWindowBuffer(unsigned int width,
+                            unsigned int height,
+                            unsigned int format,
+                            unsigned int usage) ;
+   virtual ~HWComposerNativeWindowBuffer() ;
+
+protected:
+    int busy;
+    int fenceFd;
+    int status;
+    alloc_device_t* m_alloc;
+};
+
+
+class HWComposerNativeWindow : public BaseNativeWindow {
+public:
+    HWComposerNativeWindow(unsigned int width, unsigned int height, unsigned int format);
+    ~HWComposerNativeWindow();
+
+    int getFenceBufferFd(HWComposerNativeWindowBuffer *buffer);
+    void setFenceBufferFd(HWComposerNativeWindowBuffer *buffer, int fd);
+protected:
+    // overloads from BaseNativeWindow
+    virtual int setSwapInterval(int interval);
+
+    virtual int dequeueBuffer(BaseNativeWindowBuffer** buffer, int* fenceFd);
+    virtual int queueBuffer(BaseNativeWindowBuffer* buffer, int fenceFd);
+    virtual int cancelBuffer(BaseNativeWindowBuffer* buffer, int fenceFd);
+    virtual int lockBuffer(BaseNativeWindowBuffer* buffer);
+
+    virtual unsigned int type() const;
+    virtual unsigned int width() const;
+    virtual unsigned int height() const;
+    virtual unsigned int format() const;
+    virtual unsigned int defaultWidth() const;
+    virtual unsigned int defaultHeight() const;
+    virtual unsigned int queueLength() const;
+    virtual unsigned int transformHint() const;
+    virtual unsigned int getUsage() const;
+    // perform calls
+    virtual int setUsage(int usage);
+    virtual int setBuffersFormat(int format);
+    virtual int setBuffersDimensions(int width, int height);
+    virtual int setBufferCount(int cnt);
+    virtual void present(HWComposerNativeWindowBuffer *buffer) = 0;
+
+private:
+    void destroyBuffers();
+    void allocateBuffers();
+
+private:
+    unsigned int m_usage;
+    unsigned int m_bufFormat;
+    std::vector<HWComposerNativeWindowBuffer*> m_bufList;
+    unsigned int m_bufferCount;
+    unsigned int m_nextBuffer;
+
+    int m_width;
+    int m_height;
+
+    pthread_mutex_t m_mutex;
+};
+
+#endif
+// vim: noai:ts=4:sw=4:ss=4:expandtab

--- a/compat/hwc2/tests/hybris-gralloc.c
+++ b/compat/hwc2/tests/hybris-gralloc.c
@@ -1,0 +1,337 @@
+#include <hardware/hardware.h>
+
+#include <hardware/gralloc.h>
+#if HAS_GRALLOC1_HEADER
+#include <GrallocUsageConversion.h>
+#include <hardware/gralloc1.h>
+#endif
+#include <hardware/fb.h>
+
+#include "hybris-gralloc.h"
+//#include <hybris/common/binding.h>
+
+#include <errno.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <assert.h>
+
+#include <dlfcn.h>
+
+static int version = -1;
+static hw_module_t *gralloc_hardware_module = NULL;
+
+static framebuffer_device_t *framebuffer_device = NULL;
+static gralloc_module_t *gralloc0_module;
+static alloc_device_t *gralloc0_alloc;
+
+#if HAS_GRALLOC1_HEADER
+static gralloc1_device_t *gralloc1_device = NULL;
+static int gralloc1_release_implies_delete = 0;
+static GRALLOC1_PFN_CREATE_DESCRIPTOR gralloc1_create_descriptor = NULL;
+static GRALLOC1_PFN_DESTROY_DESCRIPTOR gralloc1_destroy_descriptor = NULL;
+static GRALLOC1_PFN_SET_CONSUMER_USAGE gralloc1_set_consumer_usage = NULL;
+static GRALLOC1_PFN_SET_DIMENSIONS gralloc1_set_dimensions = NULL;
+static GRALLOC1_PFN_SET_FORMAT gralloc1_set_format = NULL;
+static GRALLOC1_PFN_SET_PRODUCER_USAGE gralloc1_set_producer_usage = NULL;
+static GRALLOC1_PFN_GET_BACKING_STORE gralloc1_get_backing_store = NULL;
+static GRALLOC1_PFN_GET_CONSUMER_USAGE gralloc1_get_consumer_usage = NULL;
+static GRALLOC1_PFN_GET_DIMENSIONS gralloc1_get_dimensions = NULL;
+static GRALLOC1_PFN_GET_FORMAT gralloc1_get_format = NULL;
+static GRALLOC1_PFN_GET_PRODUCER_USAGE gralloc1_get_producer_usage = NULL;
+static GRALLOC1_PFN_GET_STRIDE gralloc1_get_stride = NULL;
+static GRALLOC1_PFN_ALLOCATE gralloc1_allocate = NULL;
+static GRALLOC1_PFN_RETAIN gralloc1_retain = NULL;
+static GRALLOC1_PFN_RELEASE gralloc1_release = NULL;
+static GRALLOC1_PFN_GET_NUM_FLEX_PLANES gralloc1_get_num_flex_planes = NULL;
+static GRALLOC1_PFN_LOCK gralloc1_lock = NULL;
+static GRALLOC1_PFN_LOCK_FLEX gralloc1_lock_flex = NULL;
+static GRALLOC1_PFN_UNLOCK gralloc1_unlock = NULL;
+static GRALLOC1_PFN_SET_LAYER_COUNT gralloc1_set_layer_count = NULL;
+static GRALLOC1_PFN_GET_LAYER_COUNT gralloc1_get_layer_count = NULL;
+
+static void gralloc1_init(void);
+#endif
+
+// simple macros to make sure the code is only compiled if we actually have the
+// header to be able to compile it.
+// we could also use Gralloc1On0Adapter, but that would mean we need to import
+// headers and cpp files from android 8, which may not compile against older
+// android trees.
+#if HAS_GRALLOC1_HEADER
+#define GRALLOC0(code) (version == 0) { code }
+#define GRALLOC1(code) (version == 1) { code }
+#else
+#define GRALLOC0(code) (version == 0) { code }
+#define GRALLOC1(code) (0) {}
+#endif
+
+#define NO_GRALLOC { fprintf(stderr, "%s:%d: called gralloc method without gralloc loaded\n", __func__, __LINE__); assert(NULL); }
+
+void hybris_gralloc_deinitialize(void);
+
+void hybris_gralloc_initialize(int framebuffer)
+{
+    if (version == -1) {
+        if (hw_get_module(GRALLOC_HARDWARE_MODULE_ID, (const struct hw_module_t **)&gralloc_hardware_module) == 0) {
+#if HAS_GRALLOC1_HEADER
+            if ((gralloc1_open(gralloc_hardware_module, &gralloc1_device) == 0) && (gralloc1_device != NULL)) {
+                // success
+                gralloc1_init();
+                version = 1;
+                atexit(hybris_gralloc_deinitialize);
+            } else
+#endif
+            if (framebuffer) {
+                if (framebuffer_open(gralloc_hardware_module, &framebuffer_device) == 0) {
+                    if ((gralloc_open(gralloc_hardware_module, &gralloc0_alloc) == 0) && gralloc0_alloc != NULL) {
+                        // success
+                        version = 0;
+                        atexit(hybris_gralloc_deinitialize);
+                    } else {
+                        fprintf(stderr, "failed to open the gralloc 0 module (framebuffer was requested therefore defaulted to version 0)\n");
+                        assert(NULL);
+                    }
+                } else {
+                    fprintf(stderr, "failed to open the framebuffer module\n");
+                    assert(NULL);
+                }
+            } else
+            if ((gralloc_open(gralloc_hardware_module, &gralloc0_alloc) == 0) && gralloc0_alloc != NULL) {
+                // success
+                version = 0;
+                atexit(hybris_gralloc_deinitialize);
+            } else {
+                // fail
+                framebuffer_device = NULL;
+#if HAS_GRALLOC1_HEADER
+                gralloc1_device = NULL;
+#endif
+                version = -2;
+                fprintf(stderr, "failed to open gralloc module with both version 0 and 1 methods\n");
+                hybris_gralloc_deinitialize();
+                assert(NULL);
+            }
+        } else {
+            fprintf(stderr, "failed to find/load gralloc module\n");
+            assert(NULL);
+        }
+    } else {
+        // shouldn't reach here.
+        assert(NULL);
+    }
+}
+
+void hybris_gralloc_deinitialize(void)
+{
+    if (framebuffer_device) framebuffer_close(framebuffer_device);
+    framebuffer_device = NULL;
+
+    if (gralloc0_alloc) gralloc_close(gralloc0_alloc);
+    gralloc0_alloc = NULL;
+
+#if HAS_GRALLOC1_HEADER
+    if (gralloc1_device) gralloc1_close(gralloc1_device);
+    gralloc1_device = NULL;
+#endif
+
+    if (gralloc_hardware_module) dlclose(gralloc_hardware_module->dso);
+    gralloc_hardware_module = NULL;
+}
+
+#if HAS_GRALLOC1_HEADER
+static void gralloc1_init(void)
+{
+    uint32_t count = 0;
+    gralloc1_device->getCapabilities(gralloc1_device, &count, NULL);
+
+    if (count >= 1) {
+        uint32_t i;
+        int32_t *gralloc1_capabilities = (int32_t*)malloc(sizeof(int32_t) * count);
+
+        gralloc1_device->getCapabilities(gralloc1_device, &count, gralloc1_capabilities);
+
+        // currently the only one that affects us/interests us is release imply delete.
+        for (i = 0; i < count; i++) {
+            if (gralloc1_capabilities[i] == GRALLOC1_CAPABILITY_RELEASE_IMPLY_DELETE) {
+                gralloc1_release_implies_delete = 1;
+            }
+        }
+
+        free(gralloc1_capabilities);
+    }
+
+    gralloc1_create_descriptor = (GRALLOC1_PFN_CREATE_DESCRIPTOR)gralloc1_device->getFunction(gralloc1_device, GRALLOC1_FUNCTION_CREATE_DESCRIPTOR);
+    gralloc1_destroy_descriptor = (GRALLOC1_PFN_DESTROY_DESCRIPTOR)gralloc1_device->getFunction(gralloc1_device, GRALLOC1_FUNCTION_DESTROY_DESCRIPTOR);
+    gralloc1_set_consumer_usage = (GRALLOC1_PFN_SET_CONSUMER_USAGE)gralloc1_device->getFunction(gralloc1_device, GRALLOC1_FUNCTION_SET_CONSUMER_USAGE);
+    gralloc1_set_dimensions = (GRALLOC1_PFN_SET_DIMENSIONS)gralloc1_device->getFunction(gralloc1_device, GRALLOC1_FUNCTION_SET_DIMENSIONS);
+    gralloc1_set_format = (GRALLOC1_PFN_SET_FORMAT)gralloc1_device->getFunction(gralloc1_device, GRALLOC1_FUNCTION_SET_FORMAT);
+    gralloc1_set_producer_usage = (GRALLOC1_PFN_SET_PRODUCER_USAGE)gralloc1_device->getFunction(gralloc1_device, GRALLOC1_FUNCTION_SET_PRODUCER_USAGE);
+    gralloc1_get_backing_store = (GRALLOC1_PFN_GET_BACKING_STORE)gralloc1_device->getFunction(gralloc1_device, GRALLOC1_FUNCTION_GET_BACKING_STORE);
+    gralloc1_get_consumer_usage = (GRALLOC1_PFN_GET_CONSUMER_USAGE)gralloc1_device->getFunction(gralloc1_device, GRALLOC1_FUNCTION_GET_CONSUMER_USAGE);
+    gralloc1_get_dimensions = (GRALLOC1_PFN_GET_DIMENSIONS)gralloc1_device->getFunction(gralloc1_device, GRALLOC1_FUNCTION_GET_DIMENSIONS);
+    gralloc1_get_format = (GRALLOC1_PFN_GET_FORMAT)gralloc1_device->getFunction(gralloc1_device, GRALLOC1_FUNCTION_GET_FORMAT);
+    gralloc1_get_producer_usage = (GRALLOC1_PFN_GET_PRODUCER_USAGE)gralloc1_device->getFunction(gralloc1_device, GRALLOC1_FUNCTION_GET_PRODUCER_USAGE);
+    gralloc1_get_stride = (GRALLOC1_PFN_GET_STRIDE)gralloc1_device->getFunction(gralloc1_device, GRALLOC1_FUNCTION_GET_STRIDE);
+    gralloc1_allocate = (GRALLOC1_PFN_ALLOCATE)gralloc1_device->getFunction(gralloc1_device, GRALLOC1_FUNCTION_ALLOCATE);
+    gralloc1_retain = (GRALLOC1_PFN_RETAIN)gralloc1_device->getFunction(gralloc1_device, GRALLOC1_FUNCTION_RETAIN);
+    gralloc1_release = (GRALLOC1_PFN_RELEASE)gralloc1_device->getFunction(gralloc1_device, GRALLOC1_FUNCTION_RELEASE);
+    gralloc1_get_num_flex_planes = (GRALLOC1_PFN_GET_NUM_FLEX_PLANES)gralloc1_device->getFunction(gralloc1_device, GRALLOC1_FUNCTION_GET_NUM_FLEX_PLANES);
+    gralloc1_lock = (GRALLOC1_PFN_LOCK)gralloc1_device->getFunction(gralloc1_device, GRALLOC1_FUNCTION_LOCK);
+    gralloc1_lock_flex = (GRALLOC1_PFN_LOCK_FLEX)gralloc1_device->getFunction(gralloc1_device, GRALLOC1_FUNCTION_LOCK_FLEX);
+    gralloc1_unlock = (GRALLOC1_PFN_UNLOCK)gralloc1_device->getFunction(gralloc1_device, GRALLOC1_FUNCTION_UNLOCK);
+    gralloc1_set_layer_count = (GRALLOC1_PFN_SET_LAYER_COUNT)gralloc1_device->getFunction(gralloc1_device, GRALLOC1_FUNCTION_SET_LAYER_COUNT);
+    gralloc1_get_layer_count = (GRALLOC1_PFN_GET_LAYER_COUNT)gralloc1_device->getFunction(gralloc1_device, GRALLOC1_FUNCTION_GET_LAYER_COUNT);
+}
+#endif
+
+int hybris_gralloc_release(buffer_handle_t handle, int was_allocated)
+{
+    int ret = -ENOSYS;
+
+    if GRALLOC1(
+        ret = gralloc1_release(gralloc1_device, handle);
+
+        // this needs to happen if the last reference is gone, this function is
+        // only called in such cases.
+        if (!gralloc1_release_implies_delete) {
+            native_handle_close((native_handle_t*)handle);
+            native_handle_delete((native_handle_t*)handle);
+        }
+    ) else if GRALLOC0(
+        if (was_allocated) {
+            ret = gralloc0_alloc->free(gralloc0_alloc, handle);
+        } else {
+            ret = gralloc0_module->unregisterBuffer(gralloc0_module, handle);
+
+            // this needs to happen if the last reference is gone, this function is
+            // only called in such cases.
+            native_handle_close((native_handle_t*)handle);
+            native_handle_delete((native_handle_t*)handle);
+        }
+    ) else NO_GRALLOC
+
+    return ret;
+}
+
+int hybris_gralloc_retain(buffer_handle_t handle)
+{
+    int ret = -ENOSYS;
+
+    if GRALLOC1(
+        ret = gralloc1_retain(gralloc1_device, handle);
+    ) else if GRALLOC0(
+        ret = gralloc0_module->registerBuffer(gralloc0_module, handle);
+    ) else NO_GRALLOC
+
+    return ret;
+}
+
+int hybris_gralloc_allocate(int width, int height, int format, int usage, buffer_handle_t *handle_ptr, uint32_t *stride_ptr)
+{
+    int ret = -ENOSYS;
+
+    if GRALLOC1(
+        gralloc1_buffer_descriptor_t desc;
+        uint64_t producer_usage;
+        uint64_t consumer_usage;
+
+        android_convertGralloc0To1Usage(usage, &producer_usage, &consumer_usage);
+
+        // create temporary description (descriptor) of buffer to allocate
+        ret = gralloc1_create_descriptor(gralloc1_device, &desc);
+        ret |= gralloc1_set_dimensions(gralloc1_device, desc, width, height);
+        ret |= gralloc1_set_consumer_usage(gralloc1_device, desc, consumer_usage);
+        ret |= gralloc1_set_producer_usage(gralloc1_device, desc, producer_usage);
+        ret |= gralloc1_set_format(gralloc1_device, desc, format);
+
+        // actual allocation
+        ret |= gralloc1_allocate(gralloc1_device, 1, &desc, handle_ptr);
+
+        // get stride and release temporary descriptor
+        ret |= gralloc1_get_stride(gralloc1_device, *handle_ptr, stride_ptr);
+        ret |= gralloc1_destroy_descriptor(gralloc1_device, desc);
+    ) else if GRALLOC0(
+        ret = gralloc0_alloc->alloc(gralloc0_alloc,
+                                    width, height, format, usage,
+                                    handle_ptr, (int*)stride_ptr);
+    ) else NO_GRALLOC
+
+    return ret;
+}
+
+int hybris_gralloc_lock(buffer_handle_t handle, int usage, int l, int t, int w, int h, void **vaddr)
+{
+    int ret = -ENOSYS;
+
+    if GRALLOC1(
+        uint64_t producer_usage;
+        uint64_t consumer_usage;
+        gralloc1_rect_t access_region;
+
+        access_region.left = l;
+        access_region.top = t;
+        access_region.width = w;
+        access_region.height = h;
+
+        android_convertGralloc0To1Usage(usage, &producer_usage, &consumer_usage);
+
+        ret = gralloc1_lock(gralloc1_device, handle, producer_usage, consumer_usage, &access_region, vaddr, -1);
+    ) else if GRALLOC0(
+        ret = gralloc0_module->lock(gralloc0_module, handle, usage, l, t, w, h, vaddr);
+    ) else NO_GRALLOC
+
+    return ret;
+}
+
+int hybris_gralloc_unlock(buffer_handle_t handle)
+{
+    int ret = -ENOSYS;
+
+    if GRALLOC1(
+        int releaseFence = 0;
+        ret = gralloc1_unlock(gralloc1_device, handle, &releaseFence);
+        close(releaseFence);
+    ) else if GRALLOC0(
+        ret = gralloc0_module->unlock(gralloc0_module, handle);
+    ) else NO_GRALLOC
+
+    return ret;
+}
+
+// Legacy fbdev methods. these are not available in gralloc1 thus use old API.
+int hybris_gralloc_fbdev_format(void)
+{
+    assert(framebuffer_device);
+    return framebuffer_device->format;
+}
+
+int hybris_gralloc_fbdev_framebuffer_count(void)
+{
+    assert(framebuffer_device);
+    return framebuffer_device->numFramebuffers;
+}
+
+int hybris_gralloc_fbdev_setSwapInterval(int interval)
+{
+    assert(framebuffer_device);
+    return framebuffer_device->setSwapInterval(framebuffer_device, interval);
+}
+
+int hybris_gralloc_fbdev_post(buffer_handle_t handle)
+{
+    assert(framebuffer_device);
+    return framebuffer_device->post(framebuffer_device, handle);
+}
+
+int hybris_gralloc_fbdev_width(void)
+{
+    assert(framebuffer_device);
+    return framebuffer_device->width;
+}
+
+int hybris_gralloc_fbdev_height(void)
+{
+    assert(framebuffer_device);
+    return framebuffer_device->height;
+}

--- a/compat/hwc2/tests/hybris-gralloc.h
+++ b/compat/hwc2/tests/hybris-gralloc.h
@@ -1,0 +1,36 @@
+#ifndef hybris_gralloc_header_include_guard__
+#define hybris_gralloc_header_include_guard__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// for usage definitions and so on
+#if HAS_GRALLOC1_HEADER
+#include <hardware/gralloc1.h>
+#endif
+#include <hardware/gralloc.h>
+
+#include <cutils/native_handle.h>
+
+void hybris_gralloc_deinitialize(void);
+void hybris_gralloc_initialize(int framebuffer);
+void hybris_gralloc_deinitialize(void);
+int hybris_gralloc_release(buffer_handle_t handle, int was_allocated);
+int hybris_gralloc_retain(buffer_handle_t handle);
+int hybris_gralloc_allocate(int width, int height, int format, int usage, buffer_handle_t *handle, uint32_t *stride);
+int hybris_gralloc_lock(buffer_handle_t handle, int usage, int l, int t, int w, int h, void **vaddr);
+int hybris_gralloc_unlock(buffer_handle_t handle);
+int hybris_gralloc_fbdev_format(void);
+int hybris_gralloc_fbdev_framebuffer_count(void);
+int hybris_gralloc_fbdev_setSwapInterval(int interval);
+int hybris_gralloc_fbdev_post(buffer_handle_t handle);
+int hybris_gralloc_fbdev_width(void);
+int hybris_gralloc_fbdev_height(void);
+
+#ifdef __cplusplus
+};
+#endif
+
+#endif
+

--- a/compat/hwc2/tests/nativewindowbase.cpp
+++ b/compat/hwc2/tests/nativewindowbase.cpp
@@ -1,0 +1,385 @@
+#include <string.h>
+#include <system/window.h>
+#include <system/graphics.h>
+#include <hardware/gralloc.h>
+#include "support.h"
+#include <stdarg.h>
+
+extern "C" {
+#include <sync/sync.h>
+}
+
+#include "nativewindowbase.h"
+
+#include <android/log.h>
+//#define TRACE(fmt, ...) __android_log_print(ANDROID_LOG_DEBUG, "HWCNativeWindow", fmt "\n--> %s\n----> %s:%d", ##__VA_ARGS__, __FILE__, __FUNCTION__, __LINE__)
+#define TRACE(fmt, ...)
+
+BaseNativeWindowBuffer::BaseNativeWindowBuffer()
+{
+	TRACE("%p", this);
+
+	// done in ANativeWindowBuffer::ANativeWindowBuffer
+	// common.magic = ANDROID_NATIVE_WINDOW_MAGIC;
+	// common.version = sizeof(ANativeWindow);
+	// memset(common.reserved, 0, sizeof(window->native.common.reserved));
+
+	ANativeWindowBuffer::common.decRef = _decRef;
+	ANativeWindowBuffer::common.incRef = _incRef;
+	ANativeWindowBuffer::width = 0;
+	ANativeWindowBuffer::height = 0;
+	ANativeWindowBuffer::stride = 0;
+	ANativeWindowBuffer::format = 0;
+	ANativeWindowBuffer::usage = 0;
+	ANativeWindowBuffer::handle = 0;
+
+	refcount = 0;
+}
+
+
+BaseNativeWindowBuffer::~BaseNativeWindowBuffer()
+{
+	TRACE("%p", this);
+
+	ANativeWindowBuffer::common.decRef = NULL;
+	ANativeWindowBuffer::common.incRef = NULL;
+	refcount = 0;
+}
+
+
+void BaseNativeWindowBuffer::_decRef(struct android_native_base_t* base)
+{
+	ANativeWindowBuffer* self = container_of(base, ANativeWindowBuffer, common);
+	BaseNativeWindowBuffer* bnwb = static_cast<BaseNativeWindowBuffer*>(self) ;
+
+	TRACE("%p refcount = %i",bnwb, bnwb->refcount - 1);
+
+	if (__sync_fetch_and_sub(&bnwb->refcount,1) == 1)
+	{
+		delete bnwb;
+	}
+}
+
+
+
+void BaseNativeWindowBuffer::_incRef(struct android_native_base_t* base)
+{
+	ANativeWindowBuffer* self = container_of(base, ANativeWindowBuffer, common);
+	BaseNativeWindowBuffer* bnwb= static_cast<BaseNativeWindowBuffer*>(self) ;
+
+	TRACE("%p refcount = %i", bnwb, bnwb->refcount + 1);
+	__sync_fetch_and_add(&bnwb->refcount,1);
+}
+
+ANativeWindowBuffer* BaseNativeWindowBuffer::getNativeBuffer() const
+{
+	return static_cast<ANativeWindowBuffer*>(const_cast<BaseNativeWindowBuffer*>(this));
+}
+
+BaseNativeWindow::BaseNativeWindow()
+{
+	TRACE("this=%p or A %p", this, (ANativeWindow*)this);
+	// done in ANativeWindow
+	// common.magic = ANDROID_NATIVE_WINDOW_MAGIC;
+	// common.version = sizeof(ANativeWindow);
+	// memset(common.reserved, 0, sizeof(window->native.common.reserved));
+	ANativeWindow::common.decRef = _decRef;
+	ANativeWindow::common.incRef = _incRef;
+
+	const_cast<uint32_t&>(ANativeWindow::flags) = 0;
+	const_cast<float&>(ANativeWindow::xdpi) = 0;
+	const_cast<float&>(ANativeWindow::ydpi) = 0;
+	const_cast<int&>(ANativeWindow::minSwapInterval) = 0;
+	const_cast<int&>(ANativeWindow::maxSwapInterval) = 0;
+
+	ANativeWindow::setSwapInterval = _setSwapInterval;
+
+	ANativeWindow::lockBuffer_DEPRECATED = &_lockBuffer_DEPRECATED;
+	ANativeWindow::dequeueBuffer_DEPRECATED = &_dequeueBuffer_DEPRECATED;
+	ANativeWindow::queueBuffer_DEPRECATED = &_queueBuffer_DEPRECATED;
+	ANativeWindow::cancelBuffer_DEPRECATED = &_cancelBuffer_DEPRECATED;
+	ANativeWindow::queueBuffer = &_queueBuffer;
+	ANativeWindow::dequeueBuffer = &_dequeueBuffer;
+	ANativeWindow::cancelBuffer = &_cancelBuffer;
+
+	ANativeWindow::query = &_query;
+	ANativeWindow::perform = &_perform;
+
+	refcount = 0;
+}
+
+BaseNativeWindow::~BaseNativeWindow()
+{
+	TRACE("");
+	ANativeWindow::common.decRef = NULL;
+	ANativeWindow::common.incRef = NULL;
+	refcount = 0;
+}
+
+void BaseNativeWindow::_decRef(struct android_native_base_t* base)
+{
+	ANativeWindow* self = container_of(base, ANativeWindow, common);
+	BaseNativeWindow* bnw = static_cast<BaseNativeWindow*>(self);
+
+	TRACE("%p refcount = %i", bnw, bnw->refcount - 1);
+
+	if (__sync_fetch_and_sub(&bnw->refcount,1) == 1)
+	{
+		delete bnw;
+	}
+}
+
+void BaseNativeWindow::_incRef(struct android_native_base_t* base)
+{
+	ANativeWindow* self = container_of(base, ANativeWindow, common);
+	BaseNativeWindow* bnw = static_cast<BaseNativeWindow*>(self);
+
+	TRACE("%p refcount = %i", bnw, bnw->refcount + 1);
+
+
+	__sync_fetch_and_add(&bnw->refcount,1);
+}
+
+int BaseNativeWindow::_setSwapInterval(struct ANativeWindow* window, int interval)
+{
+	return static_cast<BaseNativeWindow*>(window)->setSwapInterval(interval);
+}
+
+int BaseNativeWindow::_dequeueBuffer_DEPRECATED(ANativeWindow* window, ANativeWindowBuffer** buffer)
+{
+	BaseNativeWindowBuffer* temp = static_cast<BaseNativeWindowBuffer*>(*buffer);
+	int fenceFd = -1;
+	int ret = static_cast<BaseNativeWindow*>(window)->dequeueBuffer(&temp, &fenceFd);
+
+	*buffer = static_cast<ANativeWindowBuffer*>(temp);
+
+	if (fenceFd >= 0)
+	{
+		sync_wait(fenceFd, -1);
+		close(fenceFd);
+	}
+
+	return ret;
+}
+
+int BaseNativeWindow::_dequeueBuffer(struct ANativeWindow *window, ANativeWindowBuffer **buffer, int *fenceFd)
+{
+	BaseNativeWindowBuffer *nativeBuffer = static_cast<BaseNativeWindowBuffer*>(*buffer);
+	int ret = static_cast<BaseNativeWindow*>(window)->dequeueBuffer(&nativeBuffer, fenceFd);
+	*buffer = static_cast<ANativeWindowBuffer*>(nativeBuffer);
+	return ret;
+}
+
+int BaseNativeWindow::_queueBuffer_DEPRECATED(struct ANativeWindow* window, ANativeWindowBuffer* buffer)
+{
+	BaseNativeWindow *nativeWindow = static_cast<BaseNativeWindow*>(window);
+	BaseNativeWindowBuffer *nativeBuffer = static_cast<BaseNativeWindowBuffer*>(buffer);
+
+	return nativeWindow->queueBuffer(nativeBuffer, -1);
+}
+
+int BaseNativeWindow::_queueBuffer(struct ANativeWindow *window, ANativeWindowBuffer *buffer, int fenceFd)
+{
+	BaseNativeWindow *nativeWindow = static_cast<BaseNativeWindow*>(window);
+	BaseNativeWindowBuffer *nativeBuffer = static_cast<BaseNativeWindowBuffer*>(buffer);
+
+	return nativeWindow->queueBuffer(nativeBuffer, fenceFd);
+}
+
+int BaseNativeWindow::_cancelBuffer_DEPRECATED(struct ANativeWindow* window, ANativeWindowBuffer* buffer)
+{
+	BaseNativeWindow *nativeWindow = static_cast<BaseNativeWindow*>(window);
+	BaseNativeWindowBuffer *nativeBuffer = static_cast<BaseNativeWindowBuffer*>(buffer);
+
+	return nativeWindow->cancelBuffer(nativeBuffer, -1);
+}
+
+int BaseNativeWindow::_cancelBuffer(struct ANativeWindow *window, ANativeWindowBuffer *buffer, int fenceFd)
+{
+	BaseNativeWindow *nativeWindow = static_cast<BaseNativeWindow*>(window);
+	BaseNativeWindowBuffer *nativeBuffer = static_cast<BaseNativeWindowBuffer*>(buffer);
+
+	return nativeWindow->cancelBuffer(nativeBuffer, fenceFd);
+}
+
+int BaseNativeWindow::_lockBuffer_DEPRECATED(struct ANativeWindow* window, ANativeWindowBuffer* buffer)
+{
+	return static_cast<BaseNativeWindow*>(window)->lockBuffer(static_cast<BaseNativeWindowBuffer*>(buffer));
+}
+
+const char *BaseNativeWindow::_native_window_operation(int what)
+{
+	switch (what) {
+		case NATIVE_WINDOW_SET_USAGE: return "NATIVE_WINDOW_SET_USAGE";
+		case NATIVE_WINDOW_CONNECT: return "NATIVE_WINDOW_CONNECT";
+		case NATIVE_WINDOW_DISCONNECT: return "NATIVE_WINDOW_DISCONNECT";
+		case NATIVE_WINDOW_SET_CROP: return "NATIVE_WINDOW_SET_CROP";
+		case NATIVE_WINDOW_SET_BUFFER_COUNT: return "NATIVE_WINDOW_SET_BUFFER_COUNT";
+		case NATIVE_WINDOW_SET_BUFFERS_GEOMETRY: return "NATIVE_WINDOW_SET_BUFFERS_GEOMETRY";
+		case NATIVE_WINDOW_SET_BUFFERS_TRANSFORM: return "NATIVE_WINDOW_SET_BUFFERS_TRANSFORM";
+		case NATIVE_WINDOW_SET_BUFFERS_TIMESTAMP: return "NATIVE_WINDOW_SET_BUFFERS_TIMESTAMP";
+		case NATIVE_WINDOW_SET_BUFFERS_DIMENSIONS: return "NATIVE_WINDOW_SET_BUFFERS_DIMENSIONS";
+		case NATIVE_WINDOW_SET_BUFFERS_FORMAT: return "NATIVE_WINDOW_SET_BUFFERS_FORMAT";
+		case NATIVE_WINDOW_SET_SCALING_MODE: return "NATIVE_WINDOW_SET_SCALING_MODE";
+		case NATIVE_WINDOW_LOCK: return "NATIVE_WINDOW_LOCK";
+		case NATIVE_WINDOW_UNLOCK_AND_POST: return "NATIVE_WINDOW_UNLOCK_AND_POST";
+		case NATIVE_WINDOW_API_CONNECT: return "NATIVE_WINDOW_API_CONNECT";
+		case NATIVE_WINDOW_API_DISCONNECT: return "NATIVE_WINDOW_API_DISCONNECT";
+		case NATIVE_WINDOW_SET_BUFFERS_USER_DIMENSIONS: return "NATIVE_WINDOW_SET_BUFFERS_USER_DIMENSIONS";
+		case NATIVE_WINDOW_SET_POST_TRANSFORM_CROP: return "NATIVE_WINDOW_SET_POST_TRANSFORM_CROP";
+		default: return "NATIVE_UNKNOWN_OPERATION";
+	}
+}
+const char *BaseNativeWindow::_native_query_operation(int what)
+{
+	switch (what) {
+		case NATIVE_WINDOW_WIDTH: return "NATIVE_WINDOW_WIDTH";
+		case NATIVE_WINDOW_HEIGHT: return "NATIVE_WINDOW_HEIGHT";
+		case NATIVE_WINDOW_FORMAT: return "NATIVE_WINDOW_FORMAT";
+		case NATIVE_WINDOW_MIN_UNDEQUEUED_BUFFERS: return "NATIVE_WINDOW_MIN_UNDEQUEUED_BUFFERS";
+		case NATIVE_WINDOW_QUEUES_TO_WINDOW_COMPOSER: return "NATIVE_WINDOW_QUEUES_TO_WINDOW_COMPOSER";
+		case NATIVE_WINDOW_CONCRETE_TYPE: return "NATIVE_WINDOW_CONCRETE_TYPE";
+		case NATIVE_WINDOW_DEFAULT_WIDTH: return "NATIVE_WINDOW_DEFAULT_WIDTH";
+		case NATIVE_WINDOW_DEFAULT_HEIGHT: return "NATIVE_WINDOW_DEFAULT_HEIGHT";
+		case NATIVE_WINDOW_TRANSFORM_HINT: return "NATIVE_WINDOW_TRANSFORM_HINT";
+		case NATIVE_WINDOW_CONSUMER_RUNNING_BEHIND: return "NATIVE_WINDOW_CONSUMER_RUNNING_BEHIND";
+		case NATIVE_WINDOW_DEFAULT_DATASPACE: return "NATIVE_WINDOW_DEFAULT_DATASPACE";
+		case NATIVE_WINDOW_CONSUMER_USAGE_BITS: return "NATIVE_WINDOW_CONSUMER_USAGE_BITS";
+#if ANDROID_VERSION_MAJOR>=8
+		case NATIVE_WINDOW_IS_VALID: return "NATIVE_WINDOW_IS_VALID";
+#endif
+		default: return "NATIVE_UNKNOWN_QUERY";
+	}
+}
+
+int BaseNativeWindow::_query(const struct ANativeWindow* window, int what, int* value)
+{
+	TRACE("window:%p %i %s %p", window, what, _native_query_operation(what), value);
+	const BaseNativeWindow* self=static_cast<const BaseNativeWindow*>(window);
+	switch (what) {
+		case NATIVE_WINDOW_WIDTH:
+			*value = self->width();
+			return NO_ERROR;
+		case NATIVE_WINDOW_HEIGHT:
+			*value = self->height();
+			return NO_ERROR;
+		case NATIVE_WINDOW_FORMAT:
+			*value = self->format();
+			return NO_ERROR;
+		case NATIVE_WINDOW_CONCRETE_TYPE:
+			*value = self->type();
+			return NO_ERROR;
+		case NATIVE_WINDOW_QUEUES_TO_WINDOW_COMPOSER:
+			*value = self->queueLength();
+			return NO_ERROR;
+		case NATIVE_WINDOW_DEFAULT_WIDTH:
+			*value = self->defaultWidth();
+			return NO_ERROR;
+		case NATIVE_WINDOW_DEFAULT_HEIGHT:
+			*value = self->defaultHeight();
+			return NO_ERROR;
+		case NATIVE_WINDOW_TRANSFORM_HINT:
+			*value = self->transformHint();
+			return NO_ERROR;
+		case NATIVE_WINDOW_MIN_UNDEQUEUED_BUFFERS:
+			*value = 1;
+			return NO_ERROR;
+		case NATIVE_WINDOW_DEFAULT_DATASPACE:
+			*value = HAL_DATASPACE_UNKNOWN;
+			return NO_ERROR;
+		case NATIVE_WINDOW_CONSUMER_USAGE_BITS:
+			*value = self->getUsage();
+			return NO_ERROR;
+#if ANDROID_VERSION_MAJOR>=8
+		case NATIVE_WINDOW_IS_VALID:
+			// sure :)
+			*value = 1;
+			return NO_ERROR;
+#endif
+	}
+	TRACE("EGL error: unkown window attribute! %i", what);
+	*value = 0;
+	return BAD_VALUE;
+}
+
+int BaseNativeWindow::_perform(struct ANativeWindow* window, int operation, ... )
+{
+	BaseNativeWindow* self = static_cast<BaseNativeWindow*>(window);
+	va_list args;
+	va_start(args, operation);
+
+	// FIXME
+	TRACE("operation = %s", _native_window_operation(operation));
+	switch(operation) {
+	case NATIVE_WINDOW_SET_USAGE                 : //  0,
+	{
+		int usage = va_arg(args, int);
+		va_end(args);
+		return self->setUsage(usage);
+	}
+	case NATIVE_WINDOW_CONNECT                   : //  1,   /* deprecated */
+		TRACE("connect");
+		break;
+	case NATIVE_WINDOW_DISCONNECT                : //  2,   /* deprecated */
+		TRACE("disconnect");
+		break;
+	case NATIVE_WINDOW_SET_CROP                  : //  3,   /* private */
+		TRACE("set crop");
+		break;
+	case NATIVE_WINDOW_SET_BUFFER_COUNT          : //  4,
+	{
+		int cnt = va_arg(args, int);
+		TRACE("set buffer count %i", cnt);
+		va_end(args);
+		return self->setBufferCount(cnt);
+		break;
+	}
+	case NATIVE_WINDOW_SET_BUFFERS_GEOMETRY      : //  5,   /* deprecated */
+		TRACE("set buffers geometry");
+		break;
+	case NATIVE_WINDOW_SET_BUFFERS_TRANSFORM     : //  6,
+		TRACE("set buffers transform");
+		break;
+	case NATIVE_WINDOW_SET_BUFFERS_TIMESTAMP     : //  7,
+		TRACE("set buffers timestamp");
+		break;
+	case NATIVE_WINDOW_SET_BUFFERS_DIMENSIONS    : //  8,
+	{
+		int width  = va_arg(args, int);
+		int height = va_arg(args, int);
+		va_end(args);
+		return self->setBuffersDimensions(width, height);
+	}
+	case NATIVE_WINDOW_SET_BUFFERS_FORMAT        : //  9,
+	{
+		int format = va_arg(args, int);
+		va_end(args);
+		return self->setBuffersFormat(format);
+	}
+	case NATIVE_WINDOW_SET_SCALING_MODE          : // 10,   /* private */
+		TRACE("set scaling mode");
+		break;
+	case NATIVE_WINDOW_LOCK                      : // 11,   /* private */
+		TRACE("window lock");
+		break;
+	case NATIVE_WINDOW_UNLOCK_AND_POST           : // 12,   /* private */
+		TRACE("unlock and post");
+		break;
+	case NATIVE_WINDOW_API_CONNECT               : // 13,   /* private */
+		TRACE("api connect");
+		break;
+	case NATIVE_WINDOW_API_DISCONNECT            : // 14,   /* private */
+		TRACE("api disconnect");
+		break;
+#if ANDROID_VERSION_MAJOR>=4 && ANDROID_VERSION_MINOR>=1 || ANDROID_VERSION_MAJOR>=5
+	case NATIVE_WINDOW_SET_BUFFERS_USER_DIMENSIONS : // 15, /* private */
+		TRACE("set buffers user dimensions");
+		break;
+	case NATIVE_WINDOW_SET_POST_TRANSFORM_CROP   : // 16,
+		TRACE("set post transform crop");
+		break;
+#endif
+	}
+	va_end(args);
+	return NO_ERROR;
+}

--- a/compat/hwc2/tests/nativewindowbase.h
+++ b/compat/hwc2/tests/nativewindowbase.h
@@ -1,0 +1,99 @@
+#ifndef NATIVEWINDOWBASE_H
+#define NATIVEWINDOWBASE_H
+
+/* for ICS window.h */
+#include <string.h>
+#include <system/window.h>
+#include <EGL/egl.h>
+#include "support.h"
+#include <stdarg.h>
+#include <assert.h>
+
+#ifdef DEBUG
+#include <stdio.h>
+#endif
+
+#define NO_ERROR                0L
+#define BAD_VALUE               -1
+
+/**
+ * @brief A Class to do common ANativeBuffer initialization and thunk c-style
+ *        callbacks into C++ method calls.
+ **/
+class BaseNativeWindowBuffer : public ANativeWindowBuffer
+{
+protected:
+	BaseNativeWindowBuffer();
+	virtual ~BaseNativeWindowBuffer() ;
+
+public:
+	/* When passing the buffer to EGL functions it's required to pass always the native
+	 * buffer. This method takes care about proper casting. */
+	ANativeWindowBuffer* getNativeBuffer() const;
+
+private:
+	unsigned int refcount;
+	static void _decRef(struct android_native_base_t* base);
+	static void _incRef(struct android_native_base_t* base);
+};
+
+/**
+ * @brief A Class to do common ANativeWindow initialization and thunk c-style
+ *        callbacks into C++ method calls.
+ **/
+class BaseNativeWindow : public ANativeWindow
+{
+public:
+	operator EGLNativeWindowType()
+	{
+		EGLNativeWindowType ret = reinterpret_cast<EGLNativeWindowType>(static_cast<ANativeWindow *>(this));
+		return ret;
+	}
+
+protected:
+	BaseNativeWindow();
+	virtual ~BaseNativeWindow();
+
+	// does this require more magic?
+	unsigned int refcount;
+	static void _decRef(struct android_native_base_t* base);
+	static void _incRef(struct android_native_base_t* base);
+
+	// these have to be implemented in the concrete implementation, eg. FBDEV or offscreen window
+	virtual int setSwapInterval(int interval) = 0;
+
+	virtual int dequeueBuffer(BaseNativeWindowBuffer **buffer, int *fenceFd) = 0;
+	virtual int queueBuffer(BaseNativeWindowBuffer *buffer, int fenceFd) = 0;
+	virtual int cancelBuffer(BaseNativeWindowBuffer *buffer, int fenceFd) = 0;
+	virtual int lockBuffer(BaseNativeWindowBuffer *buffer) = 0; // DEPRECATED
+
+	virtual unsigned int type() const = 0;
+	virtual unsigned int width() const = 0;
+	virtual unsigned int height() const = 0;
+	virtual unsigned int format() const = 0;
+	virtual unsigned int defaultWidth() const = 0;
+	virtual unsigned int defaultHeight() const = 0;
+	virtual unsigned int queueLength() const = 0;
+	virtual unsigned int transformHint() const = 0;
+	virtual unsigned int getUsage() const = 0;
+	//perform interfaces
+	virtual int setBuffersFormat(int format) = 0;
+	virtual int setBuffersDimensions(int width, int height) = 0;
+	virtual int setUsage(int usage) = 0;
+	virtual int setBufferCount(int cnt) = 0;
+private:
+	static int _setSwapInterval(struct ANativeWindow* window, int interval);
+	static int _dequeueBuffer_DEPRECATED(ANativeWindow* window, ANativeWindowBuffer** buffer);
+	static const char *_native_window_operation(int what);
+	static const char *_native_query_operation(int what);
+	static int _lockBuffer_DEPRECATED(struct ANativeWindow* window, ANativeWindowBuffer* buffer);
+	static int _queueBuffer_DEPRECATED(struct ANativeWindow* window, ANativeWindowBuffer* buffer);
+	static int _query(const struct ANativeWindow* window, int what, int* value);
+	static int _perform(struct ANativeWindow* window, int operation, ... );
+	static int _cancelBuffer_DEPRECATED(struct ANativeWindow* window, ANativeWindowBuffer* buffer);
+	static int _queueBuffer(struct ANativeWindow *window, ANativeWindowBuffer *buffer, int fenceFd);
+	static int _dequeueBuffer(struct ANativeWindow *window, ANativeWindowBuffer **buffer, int *fenceFd);
+	static int _cancelBuffer(struct ANativeWindow *window, ANativeWindowBuffer *buffer, int fenceFd);
+};
+
+#endif

--- a/compat/hwc2/tests/support.h
+++ b/compat/hwc2/tests/support.h
@@ -1,0 +1,17 @@
+#ifndef SUPPORT_H_
+#define SUPPORT_H_
+
+#include <stddef.h>
+
+/**
+ * container_of - cast a member of a structure out to the containing structure
+ * @ptr:	the pointer to the member.
+ * @type:	the type of the container struct this is embedded in.
+ * @member:	the name of the member within the struct.
+ *
+ */
+#define container_of(ptr, type, member) ({			\
+	const typeof( ((type *)0)->member ) *__mptr = (ptr);	\
+	(type *)( (char *)__mptr - offsetof(type,member) );})
+
+#endif

--- a/hybris/Makefile.am
+++ b/hybris/Makefile.am
@@ -12,6 +12,10 @@ if !HAS_ANDROID_8_0_0
 SUBDIRS += wifi
 endif
 
+if HAS_ANDROID_8_0_0
+SUBDIRS += hwc2
+endif
+
 if HAS_LIBNFC_NXP_HEADERS
 SUBDIRS += libnfc_nxp libnfc_ndef_nxp
 endif

--- a/hybris/configure.ac
+++ b/hybris/configure.ac
@@ -287,6 +287,8 @@ AC_CONFIG_FILES([
 	utils/Makefile
 	sf/Makefile
 	sf/libsf.pc
+	hwc2/Makefile
+	hwc2/libhwc2.pc
 	opencl/Makefile
 	opencl/OpenCL.pc
 	tests/Makefile

--- a/hybris/hwc2/Makefile.am
+++ b/hybris/hwc2/Makefile.am
@@ -1,0 +1,14 @@
+lib_LTLIBRARIES = \
+	libhwc2.la
+
+libhwc2_la_SOURCES = hwc2.c
+libhwc2_la_CFLAGS = -I$(top_srcdir)/include $(ANDROID_HEADERS_CFLAGS)
+if WANT_TRACE
+libhwc2_la_CFLAGS += -DDEBUG
+endif
+if WANT_DEBUG
+libhwc2_la_CFLAGS += -ggdb -O0
+endif
+libhwc2_la_LDFLAGS = \
+	$(top_builddir)/common/libhybris-common.la \
+	-version-info "1":"0":"0"

--- a/hybris/hwc2/Makefile.am
+++ b/hybris/hwc2/Makefile.am
@@ -12,3 +12,6 @@ endif
 libhwc2_la_LDFLAGS = \
 	$(top_builddir)/common/libhybris-common.la \
 	-version-info "1":"0":"0"
+
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = libhwc2.pc

--- a/hybris/hwc2/hwc2.c
+++ b/hybris/hwc2/hwc2.c
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2018 TheKit <nekit1000@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <dlfcn.h>
+#include <stddef.h>
+
+#include <hybris/common/binding.h>
+#include <hybris/hwc2/hwc2_compatibility_layer.h>
+
+#define COMPAT_LIBRARY_PATH		"libhwc2_compat_layer.so"
+
+HYBRIS_LIBRARY_INITIALIZE(hwc2, COMPAT_LIBRARY_PATH);
+
+HYBRIS_IMPLEMENT_FUNCTION1(hwc2, hwc2_compat_device_t*, hwc2_compat_device_new,
+                           bool);
+
+HYBRIS_IMPLEMENT_VOID_FUNCTION3(hwc2, hwc2_compat_device_register_callback,
+                                hwc2_compat_device_t*, HWC2EventListener*, int);
+
+HYBRIS_IMPLEMENT_VOID_FUNCTION3(hwc2, hwc2_compat_device_on_hotplug,
+                                hwc2_compat_device_t*, hwc2_display_t, bool);
+
+HYBRIS_IMPLEMENT_FUNCTION2(hwc2, hwc2_compat_display_t*,
+                           hwc2_compat_device_get_display_by_id,
+                           hwc2_compat_device_t*,
+                           hwc2_display_t);
+
+HYBRIS_IMPLEMENT_FUNCTION1(hwc2, HWC2DisplayConfig*,
+                           hwc2_compat_display_get_active_config,
+                           hwc2_compat_display_t*);
+
+HYBRIS_IMPLEMENT_FUNCTION1(hwc2, hwc2_error_t,
+                           hwc2_compat_display_accept_changes,
+                           hwc2_compat_display_t*);
+
+HYBRIS_IMPLEMENT_FUNCTION1(hwc2, hwc2_compat_layer_t*,
+                           hwc2_compat_display_create_layer,
+                           hwc2_compat_display_t*);
+
+HYBRIS_IMPLEMENT_VOID_FUNCTION2(hwc2, hwc2_compat_display_destroy_layer,
+                                hwc2_compat_display_t*, hwc2_compat_layer_t*);
+
+HYBRIS_IMPLEMENT_FUNCTION2(hwc2, hwc2_error_t,
+                           hwc2_compat_display_get_release_fences,
+                           hwc2_compat_display_t*, hwc2_compat_out_fences_t**);
+
+HYBRIS_IMPLEMENT_FUNCTION2(hwc2, hwc2_error_t, hwc2_compat_display_present,
+                           hwc2_compat_display_t*, int32_t*);
+
+HYBRIS_IMPLEMENT_FUNCTION5(hwc2, hwc2_error_t, hwc2_compat_display_set_client_target,
+                           hwc2_compat_display_t*, uint32_t,
+                           ANativeWindowBuffer_t*, int32_t,
+                           android_dataspace_t);
+
+HYBRIS_IMPLEMENT_FUNCTION2(hwc2, hwc2_error_t, hwc2_compat_display_set_power_mode,
+                           hwc2_compat_display_t*, int);
+HYBRIS_IMPLEMENT_FUNCTION2(hwc2, hwc2_error_t, hwc2_compat_display_set_vsync_enabled,
+                           hwc2_compat_display_t*, int);
+
+HYBRIS_IMPLEMENT_FUNCTION3(hwc2, hwc2_error_t, hwc2_compat_display_validate,
+                           hwc2_compat_display_t*, uint32_t*, uint32_t*);
+
+HYBRIS_IMPLEMENT_FUNCTION5(hwc2, hwc2_error_t, hwc2_compat_display_present_or_validate,
+                           hwc2_compat_display_t*, uint32_t*, uint32_t*,
+                           int32_t*, uint32_t*);
+
+HYBRIS_IMPLEMENT_FUNCTION2(hwc2, hwc2_error_t, hwc2_compat_layer_set_blend_mode,
+                           hwc2_compat_layer_t*, int);
+HYBRIS_IMPLEMENT_FUNCTION2(hwc2, hwc2_error_t, hwc2_compat_layer_set_color,
+                           hwc2_compat_layer_t*, hwc_color_t);
+HYBRIS_IMPLEMENT_FUNCTION2(hwc2, hwc2_error_t, hwc2_compat_layer_set_composition_type,
+                           hwc2_compat_layer_t*, int);
+HYBRIS_IMPLEMENT_FUNCTION2(hwc2, hwc2_error_t, hwc2_compat_layer_set_dataspace,
+                           hwc2_compat_layer_t*, android_dataspace_t);
+HYBRIS_IMPLEMENT_FUNCTION5(hwc2, hwc2_error_t, hwc2_compat_layer_set_display_frame,
+                           hwc2_compat_layer_t*, int32_t, int32_t,
+                           int32_t, int32_t);
+HYBRIS_IMPLEMENT_FUNCTION2(hwc2, hwc2_error_t, hwc2_compat_layer_set_plane_alpha,
+                           hwc2_compat_layer_t*, float);
+HYBRIS_IMPLEMENT_FUNCTION2(hwc2, hwc2_error_t, hwc2_compat_layer_set_sideband_stream,
+                           hwc2_compat_layer_t*, native_handle_t*);
+HYBRIS_IMPLEMENT_FUNCTION5(hwc2, hwc2_error_t, hwc2_compat_layer_set_source_crop,
+                           hwc2_compat_layer_t*, float, float, float, float);
+HYBRIS_IMPLEMENT_FUNCTION2(hwc2, hwc2_error_t, hwc2_compat_layer_set_transform,
+                           hwc2_compat_layer_t*, int);
+HYBRIS_IMPLEMENT_FUNCTION5(hwc2, hwc2_error_t, hwc2_compat_layer_set_visible_region,
+                           hwc2_compat_layer_t*, int32_t, int32_t,
+                           int32_t, int32_t);
+
+HYBRIS_IMPLEMENT_FUNCTION2(hwc2, int32_t, hwc2_compat_out_fences_get_fence,
+                           hwc2_compat_out_fences_t*, hwc2_compat_layer_t*);
+HYBRIS_IMPLEMENT_VOID_FUNCTION1(hwc2, hwc2_compat_out_fences_destroy,
+                                hwc2_compat_out_fences_t*);

--- a/hybris/hwc2/hwc2.c
+++ b/hybris/hwc2/hwc2.c
@@ -77,6 +77,9 @@ HYBRIS_IMPLEMENT_FUNCTION5(hwc2, hwc2_error_t, hwc2_compat_display_present_or_va
                            hwc2_compat_display_t*, uint32_t*, uint32_t*,
                            int32_t*, uint32_t*);
 
+HYBRIS_IMPLEMENT_FUNCTION4(hwc2, hwc2_error_t, hwc2_compat_layer_set_buffer,
+                           hwc2_compat_layer_t*, uint32_t,
+                           ANativeWindowBuffer_t*, int32_t);
 HYBRIS_IMPLEMENT_FUNCTION2(hwc2, hwc2_error_t, hwc2_compat_layer_set_blend_mode,
                            hwc2_compat_layer_t*, int);
 HYBRIS_IMPLEMENT_FUNCTION2(hwc2, hwc2_error_t, hwc2_compat_layer_set_color,

--- a/hybris/hwc2/libhwc2.pc.in
+++ b/hybris/hwc2/libhwc2.pc.in
@@ -1,0 +1,10 @@
+prefix=@prefix@
+exec_prefix=${prefix}
+libdir=@libdir@
+includedir=@includedir@
+
+Name: hybris-hwcomposer2
+Description: libhybris hwcomposer2 library
+Version: @VERSION@
+Libs: -L${libdir} -lhybris-common -lhwc2
+Cflags: -I${includedir}

--- a/hybris/include/Makefile.am
+++ b/hybris/include/Makefile.am
@@ -47,6 +47,10 @@ surface_flingerincludedir = $(includedir)/hybris/surface_flinger
 surface_flingerinclude_HEADERS = \
 	hybris/surface_flinger/surface_flinger_compatibility_layer.h
 
+hwc2includedir = $(includedir)/hybris/hwc2
+hwc2include_HEADERS = \
+	hybris/hwc2/hwc2_compatibility_layer.h
+
 inputincludedir = $(includedir)/hybris/input
 inputinclude_HEADERS = \
 	hybris/input/input_stack_compatibility_layer_codes_key.h \

--- a/hybris/include/hybris/hwc2/hwc2_compatibility_layer.h
+++ b/hybris/include/hybris/hwc2/hwc2_compatibility_layer.h
@@ -28,18 +28,24 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-	typedef void (*on_vsync_received_callback)(int32_t sequenceId, hwc2_display_t display,
-                    int64_t timestamp);
-	typedef void (*on_hotplug_received_callback)(int32_t sequenceId, hwc2_display_t display,
-                    bool connected, bool primaryDisplay);
-    typedef void (*on_refresh_received_callback)(int32_t sequenceId, hwc2_display_t display);
+    struct HWC2EventListener;
+    typedef struct HWC2EventListener HWC2EventListener;
 
-    typedef struct HWC2EventListener
+    typedef void (*on_vsync_received_callback)(HWC2EventListener* self,
+                    int32_t sequenceId, hwc2_display_t display,
+                    int64_t timestamp);
+    typedef void (*on_hotplug_received_callback)(HWC2EventListener* self,
+                    int32_t sequenceId, hwc2_display_t display,
+                    bool connected, bool primaryDisplay);
+    typedef void (*on_refresh_received_callback)(HWC2EventListener* self,
+                    int32_t sequenceId, hwc2_display_t display);
+
+    struct HWC2EventListener
     {
         on_vsync_received_callback on_vsync_received;
         on_hotplug_received_callback on_hotplug_received;
         on_refresh_received_callback on_refresh_received;
-    } HWC2EventListener;
+    };
 
     typedef struct HWC2DisplayConfig {
         hwc2_config_t id;
@@ -86,7 +92,8 @@ extern "C" {
                                            hwc2_compat_layer_t* layer);
 
     hwc2_error_t hwc2_compat_display_get_release_fences(
-                                        hwc2_compat_display_t* display,                                                hwc2_compat_out_fences_t** outFences);
+                                        hwc2_compat_display_t* display,
+                                        hwc2_compat_out_fences_t** outFences);
 
     hwc2_error_t hwc2_compat_display_present(hwc2_compat_display_t* display,
                                      int32_t* outPresentFence);
@@ -125,7 +132,7 @@ extern "C" {
     hwc2_error_t hwc2_compat_layer_set_plane_alpha(hwc2_compat_layer_t* layer,
                                            float alpha);
     hwc2_error_t hwc2_compat_layer_set_sideband_stream(hwc2_compat_layer_t* layer,
-                                               const native_handle_t* stream);
+                                               native_handle_t* stream);
     hwc2_error_t hwc2_compat_layer_set_source_crop(hwc2_compat_layer_t* layer,
                                            float left, float top,
                                            float right, float bottom);
@@ -143,4 +150,4 @@ extern "C" {
 }
 #endif
 
-#endif // UI_COMPATIBILITY_LAYER_H_
+#endif // HWC2_COMPATIBILITY_LAYER_H_

--- a/hybris/include/hybris/hwc2/hwc2_compatibility_layer.h
+++ b/hybris/include/hybris/hwc2/hwc2_compatibility_layer.h
@@ -119,6 +119,10 @@ extern "C" {
                                                  int32_t* outPresentFence,
                                                  uint32_t* state);
 
+    hwc2_error_t hwc2_compat_layer_set_buffer(hwc2_compat_layer_t* layer,
+                                              uint32_t slot,
+                                              ANativeWindowBuffer* buffer,
+                                              const int32_t acquireFenceFd);
     hwc2_error_t hwc2_compat_layer_set_blend_mode(hwc2_compat_layer_t* layer, int mode);
     hwc2_error_t hwc2_compat_layer_set_color(hwc2_compat_layer_t* layer,
                                      hwc_color_t color);

--- a/hybris/include/hybris/hwc2/hwc2_compatibility_layer.h
+++ b/hybris/include/hybris/hwc2/hwc2_compatibility_layer.h
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2018 TheKit <nekit1000@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef HWC2_COMPATIBILITY_LAYER_H_
+#define HWC2_COMPATIBILITY_LAYER_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <unistd.h>
+
+#include <hardware/hwcomposer2.h>
+#include <system/graphics.h>
+#include <system/window.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+	typedef void (*on_vsync_received_callback)(int32_t sequenceId, hwc2_display_t display,
+                    int64_t timestamp);
+	typedef void (*on_hotplug_received_callback)(int32_t sequenceId, hwc2_display_t display,
+                    bool connected, bool primaryDisplay);
+    typedef void (*on_refresh_received_callback)(int32_t sequenceId, hwc2_display_t display);
+
+    typedef struct HWC2EventListener
+    {
+        on_vsync_received_callback on_vsync_received;
+        on_hotplug_received_callback on_hotplug_received;
+        on_refresh_received_callback on_refresh_received;
+    } HWC2EventListener;
+
+    typedef struct HWC2DisplayConfig {
+        hwc2_config_t id;
+        hwc2_display_t display;
+        int32_t width;
+        int32_t height;
+        int64_t vsyncPeriod;
+        float dpiX;
+        float dpiY;
+    } HWC2DisplayConfig;
+
+    struct hwc2_compat_device;
+    typedef struct hwc2_compat_device hwc2_compat_device_t;
+
+    struct hwc2_compat_display;
+    typedef struct hwc2_compat_display hwc2_compat_display_t;
+
+    struct hwc2_compat_layer;
+    typedef struct hwc2_compat_layer hwc2_compat_layer_t;
+
+    struct hwc2_compat_out_fences;
+    typedef struct hwc2_compat_out_fences hwc2_compat_out_fences_t;
+
+    hwc2_compat_device_t* hwc2_compat_device_new(bool);
+    void hwc2_compat_device_register_callback(hwc2_compat_device_t* device,
+                                              HWC2EventListener* listener,
+                                              int composerSequenceId);
+
+    void hwc2_compat_device_on_hotplug(hwc2_compat_device_t* device,
+                                       hwc2_display_t displayId,
+                                       bool connected);
+
+    hwc2_compat_display_t* hwc2_compat_device_get_display_by_id(
+                                hwc2_compat_device_t* device,
+                                hwc2_display_t id);
+
+    HWC2DisplayConfig* hwc2_compat_display_get_active_config(
+                                hwc2_compat_display_t* display);
+
+    hwc2_error_t hwc2_compat_display_accept_changes(hwc2_compat_display_t* display);
+    hwc2_compat_layer_t* hwc2_compat_display_create_layer(hwc2_compat_display_t*
+                                                          display);
+    void hwc2_compat_display_destroy_layer(hwc2_compat_display_t* display,
+                                           hwc2_compat_layer_t* layer);
+
+    hwc2_error_t hwc2_compat_display_get_release_fences(
+                                        hwc2_compat_display_t* display,                                                hwc2_compat_out_fences_t** outFences);
+
+    hwc2_error_t hwc2_compat_display_present(hwc2_compat_display_t* display,
+                                     int32_t* outPresentFence);
+
+    hwc2_error_t hwc2_compat_display_set_client_target(hwc2_compat_display_t* display,
+                                               uint32_t slot,
+                                               ANativeWindowBuffer* buffer,
+                                               const int32_t acquireFenceFd,
+                                               android_dataspace_t dataspace);
+
+    hwc2_error_t hwc2_compat_display_set_power_mode(hwc2_compat_display_t* display,
+                                            int mode);
+    hwc2_error_t hwc2_compat_display_set_vsync_enabled(hwc2_compat_display_t* display,
+                                               int enabled);
+
+    hwc2_error_t hwc2_compat_display_validate(hwc2_compat_display_t* display,
+                                         uint32_t* outNumTypes,
+                                         uint32_t* outNumRequests);
+
+    hwc2_error_t hwc2_compat_display_present_or_validate(hwc2_compat_display_t* display,
+                                                 uint32_t* outNumTypes,
+                                                 uint32_t* outNumRequests,
+                                                 int32_t* outPresentFence,
+                                                 uint32_t* state);
+
+    hwc2_error_t hwc2_compat_layer_set_blend_mode(hwc2_compat_layer_t* layer, int mode);
+    hwc2_error_t hwc2_compat_layer_set_color(hwc2_compat_layer_t* layer,
+                                     hwc_color_t color);
+    hwc2_error_t hwc2_compat_layer_set_composition_type(hwc2_compat_layer_t* layer,
+                                                int type);
+    hwc2_error_t hwc2_compat_layer_set_dataspace(hwc2_compat_layer_t* layer,
+                                         android_dataspace_t dataspace);
+    hwc2_error_t hwc2_compat_layer_set_display_frame(hwc2_compat_layer_t* layer,
+                                             int32_t left, int32_t top,
+                                             int32_t right, int32_t bottom);
+    hwc2_error_t hwc2_compat_layer_set_plane_alpha(hwc2_compat_layer_t* layer,
+                                           float alpha);
+    hwc2_error_t hwc2_compat_layer_set_sideband_stream(hwc2_compat_layer_t* layer,
+                                               const native_handle_t* stream);
+    hwc2_error_t hwc2_compat_layer_set_source_crop(hwc2_compat_layer_t* layer,
+                                           float left, float top,
+                                           float right, float bottom);
+    hwc2_error_t hwc2_compat_layer_set_transform(hwc2_compat_layer_t* layer,
+                                         int transform);
+    hwc2_error_t hwc2_compat_layer_set_visible_region(hwc2_compat_layer_t* layer,
+                                              int32_t left, int32_t top,
+                                              int32_t right, int32_t bottom);
+
+    int32_t hwc2_compat_out_fences_get_fence(hwc2_compat_out_fences_t* fences,
+                                             hwc2_compat_layer_t* layer);
+    void hwc2_compat_out_fences_destroy(hwc2_compat_out_fences_t* fences);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // UI_COMPATIBILITY_LAYER_H_

--- a/hybris/tests/Makefile.am
+++ b/hybris/tests/Makefile.am
@@ -27,6 +27,9 @@ if HAS_ANDROID_5_0_0
 bin_PROGRAMS += test_hwcomposer
 endif
 
+if HAS_ANDROID_8_0_0
+bin_PROGRAMS += test_hwc2
+endif
 
 if HAS_LIBNFC_NXP_HEADERS
 # test_nfc depends on NFC hardware HAL interface, which is only
@@ -229,4 +232,24 @@ test_opencl_CFLAGS = \
 test_opencl_LDADD = \
 	$(top_builddir)/common/libhybris-common.la \
 	$(top_builddir)/opencl/libOpenCL.la
+
+test_hwc2_SOURCES = test_hwc2.cpp
+test_hwc2_CXXFLAGS = \
+	-I$(top_srcdir)/include \
+	$(ANDROID_HEADERS_CFLAGS) \
+	-I$(top_srcdir)/common \
+	-I$(top_srcdir)/egl/platforms/common \
+	-I$(top_srcdir)/egl/platforms/hwcomposer \
+	-I$(top_srcdir)/libsync \
+	-std=gnu++11
+
+test_hwc2_LDADD = \
+	-lm \
+	$(top_builddir)/common/libhybris-common.la \
+	$(top_builddir)/egl/platforms/hwcomposer/libhybris-hwcomposerwindow.la \
+	$(top_builddir)/egl/platforms/common/libhybris-eglplatformcommon.la \
+	$(top_builddir)/egl/libEGL.la \
+	$(top_builddir)/glesv2/libGLESv2.la \
+	$(top_builddir)/libsync/libsync.la \
+	$(top_builddir)/hwc2/libhwc2.la
 

--- a/hybris/tests/test_hwc2.cpp
+++ b/hybris/tests/test_hwc2.cpp
@@ -183,14 +183,14 @@ void HWComposer::present(HWComposerNativeWindowBuffer *buffer)
     lastPresentFence = presentFence;
 }
 
-void onVsyncReceived(int32_t sequenceId, hwc2_display_t display,
-                            int64_t timestamp)
+void onVsyncReceived(HWC2EventListener* listener, int32_t sequenceId,
+                     hwc2_display_t display, int64_t timestamp)
 {
 }
 
-void onHotplugReceived(int32_t sequenceId, hwc2_display_t display,
-                            bool connected,
-                            bool primaryDisplay)
+void onHotplugReceived(HWC2EventListener* listener, int32_t sequenceId,
+                       hwc2_display_t display, bool connected,
+                       bool primaryDisplay)
 {
     HYBRIS_INFO("onHotplugReceived(%d, %" PRIu64 ", %s, %s)",
         sequenceId, display,
@@ -201,7 +201,8 @@ void onHotplugReceived(int32_t sequenceId, hwc2_display_t display,
     hwc2_compat_device_on_hotplug(hwcDevice, display, connected);
 }
 
-void onRefreshReceived(int32_t sequenceId, hwc2_display_t display)
+void onRefreshReceived(HWC2EventListener* listener,
+                       int32_t sequenceId, hwc2_display_t display)
 {
 }
 

--- a/hybris/tests/test_hwc2.cpp
+++ b/hybris/tests/test_hwc2.cpp
@@ -1,0 +1,344 @@
+/*
+ * Copyright (C) 2018 TheKit <nekit1000@gmail.com>
+ * Copyright (c) 2012 Carsten Munk <carsten.munk@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <math.h>
+#include <mutex>
+
+#include <EGL/egl.h>
+#include <GLES2/gl2.h>
+#include <cutils/log.h>
+#include <sync/sync.h>
+
+#include <hwcomposer_window.h>
+
+#include <hybris/hwc2/hwc2_compatibility_layer.h>
+#include "logging.h"
+
+const char vertex_src [] =
+"                                        \
+   attribute vec4        position;       \
+   varying mediump vec2  pos;            \
+   uniform vec4          offset;         \
+                                         \
+   void main()                           \
+   {                                     \
+      gl_Position = position + offset;   \
+      pos = position.xy;                 \
+   }                                     \
+";
+
+
+const char fragment_src [] =
+"                                                      \
+   varying mediump vec2    pos;                        \
+   uniform mediump float   phase;                      \
+                                                       \
+   void  main()                                        \
+   {                                                   \
+      gl_FragColor  =  vec4( 1., 0.9, 0.7, 1.0 ) *     \
+        cos( 30.*sqrt(pos.x*pos.x + 1.5*pos.y*pos.y)   \
+             + atan(pos.y,pos.x) - phase );            \
+   }                                                   \
+";
+
+GLuint load_shader(const char *shader_source, GLenum type)
+{
+    GLuint  shader = glCreateShader(type);
+
+    glShaderSource(shader, 1, &shader_source, NULL);
+    glCompileShader(shader);
+
+    return shader;
+}
+
+
+GLfloat norm_x    =  0.0;
+GLfloat norm_y    =  0.0;
+GLfloat offset_x  =  0.0;
+GLfloat offset_y  =  0.0;
+GLfloat p1_pos_x  =  0.0;
+GLfloat p1_pos_y  =  0.0;
+
+GLint phase_loc;
+GLint offset_loc;
+GLint position_loc;
+
+const float vertexArray[] = {
+    0.0,  1.0,  0.0,
+    -1.,  0.0,  0.0,
+    0.0, -1.0,  0.0,
+    1.,  0.0,  0.0,
+    0.0,  1.,  0.0
+};
+
+hwc2_compat_device_t* hwcDevice;
+
+class HWComposer : public HWComposerNativeWindow
+{
+    private:
+        hwc2_compat_layer_t *layer;
+        hwc2_compat_display_t *hwcDisplay;
+        int lastPresentFence = -1;
+    protected:
+        void present(HWComposerNativeWindowBuffer *buffer);
+
+    public:
+
+        HWComposer(unsigned int width, unsigned int height, unsigned int format,
+                hwc2_compat_display_t *display, hwc2_compat_layer_t *layer);
+        void set();
+};
+
+HWComposer::HWComposer(unsigned int width, unsigned int height,
+                    unsigned int format, hwc2_compat_display_t* display,
+                    hwc2_compat_layer_t *layer) :
+                    HWComposerNativeWindow(width, height, format)
+{
+    this->layer = layer;
+    this->hwcDisplay = display;
+}
+
+void HWComposer::present(HWComposerNativeWindowBuffer *buffer)
+{
+    uint32_t numTypes = 0;
+    uint32_t numRequests = 0;
+    hwc2_display_t displayId = 0;
+
+    hwc2_error_t error = hwc2_compat_display_validate(hwcDisplay, &numTypes,
+                                                      &numRequests);
+
+    if (error != HWC2_ERROR_NONE && error != HWC2_ERROR_HAS_CHANGES) {
+        HYBRIS_ERROR("prepare: validate failed for display %lu: %s (%d)", displayId,
+              to_string(static_cast<HWC2::Error>(error)).c_str(), error);
+        return;
+    }
+
+    if (numTypes || numRequests) {
+        HYBRIS_ERROR("prepare: validate required changes for display %lu: %s (%d)",
+              displayId, to_string(static_cast<HWC2::Error>(error)).c_str(),
+              error);
+        return;
+    }
+
+    error = hwc2_compat_display_accept_changes(hwcDisplay);
+    if (error != HWC2_ERROR_NONE) {
+        HYBRIS_ERROR("prepare: acceptChanges failed: %s",
+              to_string(static_cast<HWC2::Error>(error)).c_str());
+        return;
+    }
+
+    hwc2_compat_display_set_client_target(hwcDisplay, /* slot */0, buffer,
+                                          getFenceBufferFd(buffer),
+                                          HAL_DATASPACE_UNKNOWN);
+
+    int presentFence;
+    hwc2_compat_display_present(hwcDisplay, &presentFence);
+
+    if (error != HWC2_ERROR_NONE) {
+        HYBRIS_ERROR("presentAndGetReleaseFences: failed for display %lu: %s (%d)",
+              displayId,
+              to_string(static_cast<HWC2::Error>(error)).c_str(), error);
+        return;
+    }
+
+    hwc2_compat_out_fences_t* fences;
+    error = hwc2_compat_display_get_release_fences(
+        hwcDisplay, &fences);
+
+    if (error != HWC2_ERROR_NONE) {
+        HYBRIS_ERROR("presentAndGetReleaseFences: Failed to get release fences "
+              "for display %lu: %s (%d)",
+              displayId, to_string(static_cast<HWC2::Error>(error)).c_str(),
+              error);
+        return;
+    }
+
+    int fenceFd = hwc2_compat_out_fences_get_fence(fences, layer);
+    if (fenceFd != -1)
+        setFenceBufferFd(buffer, fenceFd);
+
+    hwc2_compat_out_fences_destroy(fences);
+
+    if (lastPresentFence != -1) {
+        sync_wait(lastPresentFence, -1);
+        close(lastPresentFence);
+    }
+    lastPresentFence = presentFence;
+}
+
+void onVsyncReceived(int32_t sequenceId, hwc2_display_t display,
+                            int64_t timestamp)
+{
+}
+
+void onHotplugReceived(int32_t sequenceId, hwc2_display_t display,
+                            bool connected,
+                            bool primaryDisplay)
+{
+    HYBRIS_INFO("onHotplugReceived(%d, %" PRIu64 ", %s, %s)",
+        sequenceId, display,
+        connected ?
+                "connected" : "disconnected",
+        primaryDisplay ? "primary" : "external");
+
+    hwc2_compat_device_on_hotplug(hwcDevice, display, connected);
+}
+
+void onRefreshReceived(int32_t sequenceId, hwc2_display_t display)
+{
+}
+
+HWC2EventListener eventListener = {
+    &onVsyncReceived,
+    &onHotplugReceived,
+    &onRefreshReceived
+};
+
+int main()
+{
+    EGLDisplay display;
+    EGLConfig ecfg;
+    EGLint num_config;
+    EGLint attr[] = {       // some attributes to set up our egl-interface
+        EGL_BUFFER_SIZE, 32,
+        EGL_RENDERABLE_TYPE,
+        EGL_OPENGL_ES2_BIT,
+        EGL_NONE
+    };
+    EGLSurface surface;
+    EGLint ctxattr[] = {
+        EGL_CONTEXT_CLIENT_VERSION, 2,
+        EGL_NONE
+    };
+    EGLContext context;
+
+    EGLBoolean rv;
+
+    int err;
+    int composerSequenceId = 0;
+
+    hwcDevice = hwc2_compat_device_new(false);
+    assert(hwcDevice);
+
+    hwc2_compat_device_register_callback(hwcDevice, &eventListener,
+                                         composerSequenceId);
+
+    hwc2_compat_display_t* hwcDisplay;
+    for (int i = 0; i < 5 * 1000; ++i) {
+        /* Wait at most 5s for hotplug events */
+        if ((hwcDisplay = hwc2_compat_device_get_display_by_id(hwcDevice, 0)))
+            break;
+        usleep(1000);
+    }
+    assert(hwcDisplay);
+
+    hwc2_compat_display_set_power_mode(hwcDisplay, HWC2_POWER_MODE_ON);
+
+    HWC2DisplayConfig* config = hwc2_compat_display_get_active_config(hwcDisplay);
+
+    printf("width: %i height: %i\n", config->width, config->height);
+
+    hwc2_compat_layer_t* layer = hwc2_compat_display_create_layer(hwcDisplay);
+
+    hwc2_compat_layer_set_composition_type(layer, HWC2_COMPOSITION_CLIENT);
+    hwc2_compat_layer_set_blend_mode(layer, HWC2_BLEND_MODE_NONE);
+    hwc2_compat_layer_set_source_crop(layer, 0.0f, 0.0f, config->width,
+                                      config->height);
+    hwc2_compat_layer_set_display_frame(layer, 0, 0, config->width,
+                                        config->height);
+    hwc2_compat_layer_set_visible_region(layer, 0, 0, config->width,
+                                         config->height);
+
+    HWComposer *win = new HWComposer(config->width, config->height,
+                                     HAL_PIXEL_FORMAT_RGBA_8888, hwcDisplay,
+                                     layer);
+    printf("created native window\n");
+    /* Not needed with hybris window platform
+     * hybris_gralloc_initialize(0); */
+
+    display = eglGetDisplay(EGL_DEFAULT_DISPLAY);
+    assert(eglGetError() == EGL_SUCCESS);
+    assert(display != EGL_NO_DISPLAY);
+
+    rv = eglInitialize(display, 0, 0);
+    assert(eglGetError() == EGL_SUCCESS);
+    assert(rv == EGL_TRUE);
+
+    eglChooseConfig((EGLDisplay) display, attr, &ecfg, 1, &num_config);
+    assert(eglGetError() == EGL_SUCCESS);
+    assert(rv == EGL_TRUE);
+
+    surface = eglCreateWindowSurface((EGLDisplay) display, ecfg,
+        (EGLNativeWindowType) static_cast<ANativeWindow *> (win), NULL);
+    assert(eglGetError() == EGL_SUCCESS);
+    assert(surface != EGL_NO_SURFACE);
+
+    context = eglCreateContext((EGLDisplay) display, ecfg, EGL_NO_CONTEXT,
+                               ctxattr);
+    assert(eglGetError() == EGL_SUCCESS);
+    assert(context != EGL_NO_CONTEXT);
+
+    assert(eglMakeCurrent((EGLDisplay) display, surface, surface,
+                          context) == EGL_TRUE);
+
+    const char *version = (const char *)glGetString(GL_VERSION);
+    assert(version);
+    printf("%s\n",version);
+
+    GLuint vertexShader = load_shader (vertex_src, GL_VERTEX_SHADER);
+    GLuint fragmentShader = load_shader(fragment_src, GL_FRAGMENT_SHADER);
+
+    GLuint shaderProgram = glCreateProgram();
+    glAttachShader(shaderProgram, vertexShader);
+    glAttachShader(shaderProgram, fragmentShader);
+
+    glLinkProgram(shaderProgram);
+    glUseProgram(shaderProgram);
+
+    position_loc = glGetAttribLocation(shaderProgram, "position");
+    phase_loc = glGetUniformLocation(shaderProgram, "phase");
+    offset_loc = glGetUniformLocation(shaderProgram, "offset");
+
+    if (position_loc < 0 ||  phase_loc < 0 || offset_loc < 0) {
+        return 1;
+    }
+
+    glClearColor (1., 1., 1., 1.); // background color
+    float phase = 0;
+
+    for (int i=0; i<60*60; ++i) {
+        glClear(GL_COLOR_BUFFER_BIT);
+        glUniform1f (phase_loc, phase);
+        phase = fmodf (phase + 0.5f, 2.f * 3.141f);
+
+        glUniform4f(offset_loc, offset_x, offset_y, 0.0, 0.0);
+
+        glVertexAttribPointer(position_loc, 3, GL_FLOAT,
+                              GL_FALSE, 0, vertexArray);
+        glEnableVertexAttribArray (position_loc);
+        glDrawArrays (GL_TRIANGLE_STRIP, 0, 5);
+
+        eglSwapBuffers ((EGLDisplay) display, surface);
+    }
+
+    printf("stop\n");
+
+    return 0;
+}


### PR DESCRIPTION
This changeset allows utilizing new HWComposer 2 API for graphics output on Android 8 and newer.

The basic idea is to wrap HWC2.cpp class from SurfaceFlinger (https://android.googlesource.com/platform/frameworks/native/+/master/services/surfaceflinger/DisplayHardware/HWC2.cpp). That class utilizes underlying HIDL interface and communicates with hwcomposer HAL over binder/FMQ. libhwc2_compat_layer is a C interface library over it which can be loaded with libhybris, similar to e.g. libsf_compat_layer and libmedia_compat_layer.

compat/hwc2/tests subfolder contains code ported from libhybris to compile inside Android tree, which is useful to test compatibility layer directly on Android without libhybris involved.